### PR TITLE
Allow plugins to be installed with shorthand user/repo notation

### DIFF
--- a/lib/heroku/plugin.rb
+++ b/lib/heroku/plugin.rb
@@ -91,6 +91,11 @@ module Heroku
     end
 
     def initialize(uri)
+      # Account for shorthand notation
+      unless uri.include?("://") || uri.include?("heroku_plugin")
+        uri = "git://github.com/#{uri}.git"
+      end
+
       @uri = uri
       guess_name(uri)
     end

--- a/spec/heroku/plugin_spec.rb
+++ b/spec/heroku/plugin_spec.rb
@@ -10,9 +10,18 @@ module Heroku
       Plugin.directory.should == '/home/user/.heroku/plugins'
     end
 
-    it "extracts the name from git urls" do
-      Plugin.new('git://github.com/heroku/plugin.git').name.should == 'plugin'
+    describe "initialization" do
+
+      it "extracts the name from git urls" do
+        Plugin.new('git://github.com/heroku/plugin.git').name.should == 'plugin'
+      end
+
+      it "accepts a user/repo pair as an alernative to a full git url" do
+        Plugin.new('zeke/geek').uri.should == 'git://github.com/zeke/geek.git'
+      end
+
     end
+
 
     describe "management" do
       before(:each) do


### PR DESCRIPTION
This patch makes `heroku plugins:install tpope/heroku-binstubs` work just like `heroku plugins:install https://github.com/ddollar/heroku-redis-cli`