### PR TITLE
Enabled recursive Git submodule initialization for `heroku git:clone`

### DIFF
--- a/lib/heroku/command/git.rb
+++ b/lib/heroku/command/git.rb
@@ -28,7 +28,7 @@ class Heroku::Command::Git < Heroku::Command::Base
     git_url = api.get_app(name).body["git_url"]
 
     puts "Cloning from app '#{name}'..."
-    system "git clone -o #{remote} #{git_url} #{directory}".strip
+    system "git clone -o #{remote} #{git_url} #{directory} --recursive".strip
   end
 
   alias_command "clone", "git:clone"


### PR DESCRIPTION
This is a pretty simple edit that allows convenient use of Git submodules from within the Heroku client. All it does is add the "--recursive" flag to the system call to Git; this will automatically initialize and update [potentially nested] submodules. This can be very useful for collaborating on large, complex projects! ([documentation](http://git-scm.com/docs/git-submodule))