### PR TITLE
(>ლ)

### DIFF
--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -197,7 +197,7 @@ module Heroku::Helpers::HerokuPostgresql
           else
             attachment = resolver.resolve(val)
             if attachment.starter_plan?
-              error("#{opt.tr 'f', 'F'} is only available on production databases.")
+              error("#{opt.capitalize} is only available on production databases.")
             end
             argument_url = attachment.url
           end


### PR DESCRIPTION
Fix bug with 'rollback' not being capitalized properly in error message.