### PR TITLE
feature/certs-generate (this time for sure!)

### DIFF
--- a/lib/heroku/open_ssl.rb
+++ b/lib/heroku/open_ssl.rb
@@ -1,0 +1,93 @@
+require "heroku/helpers"
+require "tempfile"
+
+module Heroku
+  module OpenSSL
+    def self.openssl(*args)
+      if args.empty?
+        ENV["OPENSSL"] || "openssl"
+      else
+        system(openssl, *args)
+      end
+    end
+    
+    def self.openssl=(val)
+      @checked = false
+      ENV["OPENSSL"] = val
+    end
+    
+    class CertificateRequest
+      attr_accessor :domain, :subject, :key_size, :self_signed
+      
+      def initialize()
+        @key_size = 2048
+        @self_signed = false
+        super
+      end
+      
+      def generate
+        if self_signed
+          generate_self_signed_certificate
+        else
+          generate_csr
+        end
+      end
+      
+      class Result
+        attr_accessor :request, :key_file, :csr_file, :crt_file
+        
+        def initialize(request, key_file, csr_file, crt_file)
+          @request = request.dup
+          @key_file, @csr_file, @crt_file = key_file, csr_file, crt_file
+        end
+      end
+      
+    private
+      def generate_csr
+        keyfile = "#{domain}.key"
+        csrfile = "#{domain}.csr"
+        
+        openssl_req_new(keyfile, csrfile) or raise GenericError, "Key and CSR generation failed: #{$?}"
+        
+        return Result.new(self, keyfile, csrfile, nil)
+      end
+    
+      def generate_self_signed_certificate
+        keyfile = "#{domain}.key"
+        crtfile = "#{domain}.crt"
+        
+        openssl_req_new(keyfile, crtfile, "-x509") or raise GenericError, "Key and self-signed certificate generation failed: #{$?}"
+        
+        return Result.new(self, keyfile, nil, crtfile)
+      end
+      
+      def openssl_req_new(keyfile, outfile, *args)
+        Heroku::OpenSSL.ensure_openssl_installed!
+        Heroku::OpenSSL.openssl("req", "-new", "-newkey", "rsa:#{key_size}", "-nodes", "-keyout", keyfile, "-out", outfile, "-subj", subject, *args)
+      end
+    end
+    
+    class GenericError < StandardError; end
+
+    class NotInstalledError < GenericError
+      include Heroku::Helpers
+  
+      def installation_hint
+        if running_on_a_mac?
+          "With Homebrew <http://brew.sh> installed, run the following command:\n$ brew install openssl"
+        elsif running_on_windows?
+          "Download and install OpenSSL from <http://slproweb.com/products/Win32OpenSSL.html>."
+        else
+          # Probably some kind of Linux or other Unix. Who knows what package manager they're using?
+          "Make sure your package manager's 'openssl' package is installed."
+        end
+      end
+    end
+    
+    def self.ensure_openssl_installed!
+      return if @checked
+      openssl("version") or raise NotInstalledError
+      @checked = true
+    end
+  end
+end

--- a/spec/heroku/command/certs_spec.rb
+++ b/spec/heroku/command/certs_spec.rb
@@ -239,5 +239,148 @@ New active certificate details:
         STDERR
       end
     end
+    
+    describe "certs:generate" do
+      context "fails early" do
+        it "if domain not specified" do
+          stdout, stderr = execute("certs:generate")
+          expect(stdout).to eq(" !    certs:generate must specify a domain\n")
+        end
+      end
+      
+      context "successfully" do
+        let(:request) do
+          request = Heroku::OpenSSL::CertificateRequest.new
+          expect(Heroku::OpenSSL::CertificateRequest).to receive(:new).and_return(request)
+        
+          expect(request).to receive(:generate) do
+            if request.self_signed
+              Heroku::OpenSSL::CertificateRequest::Result.new(request, 'keyfile', nil, 'crtfile')
+            else
+              Heroku::OpenSSL::CertificateRequest::Result.new(request, 'keyfile', 'csrfile', nil)
+            end
+          end
+        
+          request
+        end
+      
+        before(:each) do
+          stub_core.ssl_endpoint_list("example").returns([endpoint])
+          request()
+        end
+        
+        describe "with subject prompts" do
+          it "emitted if no parts of subject provided" do
+            expect_prompts /Owner/ => "Heroku", /Country/ => 'US', /State/ => 'California', /City/ => 'San Francisco'
+            stub_core.ssl_endpoint_list("example").returns([endpoint])
+        
+            stdout, stderr = execute("certs:generate example.com")
+        
+            expect(request.domain).to eq("example.com")
+            expect(request.subject).to eq("/C=US/ST=California/L=San Francisco/O=Heroku/CN=example.com")
+          end
+      
+          it "not emitted if any part of subject is specified" do
+            expect_prompts()
+            stub_core.ssl_endpoint_list("example").returns([endpoint])
+        
+            stdout, stderr = execute("certs:generate example.com --owner Heroku")
+        
+            expect(request.domain).to eq("example.com")
+            expect(request.subject).to eq("/O=Heroku/CN=example.com")
+          end
+      
+          it "not emitted if --now is specified" do
+            expect_prompts()
+        
+            stdout, stderr = execute("certs:generate example.com --now")
+        
+            expect(request.domain).to eq("example.com")
+            expect(request.subject).to eq("/CN=example.com")
+          end
+      
+          it "not emitted if --subject is specified" do
+            expect_prompts()
+        
+            stdout, stderr = execute("certs:generate example.com --subject SOMETHING")
+        
+            expect(request.domain).to eq("example.com")
+            expect(request.subject).to eq("SOMETHING")
+          end
+        
+          def expect_prompts(hash = {})
+            hash.each do |question, answer|
+              expect_any_instance_of(Heroku::Command::Certs).to receive(:prompt).with(question).and_return(answer)
+            end
+            expect_any_instance_of(Heroku::Command::Certs).not_to receive(:prompt)
+          end
+        end
+        
+        describe "without --selfsigned" do
+          it "does not request a self-signed certificate" do
+            execute("certs:generate example.com --now")
+            expect(request.self_signed).to be false
+          end
+          
+          it "says it generated a key and CSR" do
+            stdout, stderr = execute("certs:generate example.com --now")
+            expect(stderr).to match(/^Your key and certificate signing request have been generated.$/)
+          end
+          
+          it "says the name of the CSR file" do
+            stdout, stderr = execute("certs:generate example.com --now")
+            expect(stderr).to match(/^Submit the CSR in 'csrfile' to your preferred certificate authority.$/)
+          end
+        end
+        
+        describe "with --selfsigned" do
+          it "requests a self-signed certificate" do
+            execute("certs:generate example.com --selfsigned --now")
+            expect(request.self_signed).to be true
+          end
+          
+          it "says it generated a key and self-signed certificate" do
+            stdout, stderr = execute("certs:generate example.com --selfsigned --now")
+            expect(stderr).to match(/^Your key and self-signed certificate have been generated.$/)
+          end
+          
+          it "says the name of the certificate file in the command" do
+            stdout, stderr = execute("certs:generate example.com --selfsigned --now")
+            expect(stderr).to match(/crtfile keyfile$/)
+          end
+        end
+        
+        describe "suggests next step" do
+          it "should be certs:add when domain is new" do
+            stdout, stderr = execute("certs:generate example.com --now")
+            expect(stderr).to match(/^\$ heroku certs:add CERTFILE keyfile$/)
+          end
+          
+          it "should be certs:update when domain is known" do
+            stdout, stderr = execute("certs:generate example.org --now")
+            expect(stderr).to match(/^\$ heroku certs:update CERTFILE keyfile$/)
+          end
+          
+          it "should be addons:add and certs:add when app doesn't have ssl:endpoint" do
+            stub_core.ssl_endpoint_list("example") { raise RestClient::Forbidden }
+            stdout, stderr = execute("certs:generate example.org --now")
+            expect(stderr).to match(/^\$ heroku addons:add ssl:endpoint$/)
+            expect(stderr).to match(/^\$ heroku certs:add CERTFILE keyfile$/)
+          end
+        end
+        
+        describe "key size" do
+          it "is 2048 unless otherwise specified" do
+            execute("certs:generate example.com --now")
+            expect(request.key_size).to eq(2048)
+          end
+          
+          it "can be changed using --keysize" do
+            execute("certs:generate example.com --now --keysize 4096")
+            expect(request.key_size).to eq(4096)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/heroku/open_ssl_spec.rb
+++ b/spec/heroku/open_ssl_spec.rb
@@ -1,0 +1,204 @@
+require "heroku/open_ssl"
+
+describe Heroku::OpenSSL do
+  describe :openssl do
+    it "returns 'openssl' when nothing else is set" do
+      expect(Heroku::OpenSSL.openssl).to eq("openssl")
+    end
+
+    it "returns the environment's 'OPENSSL' variable when it's set" do
+      ENV['OPENSSL'] = '/usr/bin/openssl'
+      expect(Heroku::OpenSSL.openssl).to eq('/usr/bin/openssl')
+      ENV['OPENSSL'] = nil
+    end
+    
+    it "can be set with openssl=" do
+      Heroku::OpenSSL.openssl = '/usr/local/bin/openssl'
+      expect(Heroku::OpenSSL.openssl).to eq('/usr/local/bin/openssl')
+      Heroku::OpenSSL.openssl = nil
+    end
+    
+    it "runs openssl(1) when passed arguments" do
+      expect(Heroku::OpenSSL).to receive(:system).with("openssl", "version").and_return(true)
+      expect(Heroku::OpenSSL.openssl("version")).to be true
+    end
+  end
+  
+  describe :ensure_openssl_installed! do
+    it "calls openssl(1) to ensure it's available" do
+      expect(Heroku::OpenSSL).to receive(:openssl).with("version").and_return(true)
+      Heroku::OpenSSL.ensure_openssl_installed!
+    end
+    
+    it "detects openssl(1) is available when it is available" do
+      expect { Heroku::OpenSSL.ensure_openssl_installed! }.not_to raise_error
+    end
+    
+    it "detects openssl(1) is absent when it isn't available" do
+      Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
+      expect { Heroku::OpenSSL.ensure_openssl_installed! }.to raise_error(Heroku::OpenSSL::NotInstalledError)
+      Heroku::OpenSSL.openssl = nil
+    end
+    
+    it "gives good installation advice on a Mac" do
+      Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
+      expect { Heroku::OpenSSL.ensure_openssl_installed! }.to raise_error(Heroku::OpenSSL::NotInstalledError) { |ex|
+        allow(ex).to receive(:running_on_a_mac?).and_return(true)
+        allow(ex).to receive(:running_on_windows?).and_return(false)
+        expect(ex.installation_hint).to match(/brew install openssl/)
+      }
+      Heroku::OpenSSL.openssl = nil
+    end
+    
+    it "gives good installation advice on Windows" do
+      Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
+      expect { Heroku::OpenSSL.ensure_openssl_installed! }.to raise_error(Heroku::OpenSSL::NotInstalledError) { |ex|
+        allow(ex).to receive(:running_on_a_mac?).and_return(false)
+        allow(ex).to receive(:running_on_windows?).and_return(true)
+        expect(ex.installation_hint).to match(/Win32OpenSSL\.html/)
+      }
+      Heroku::OpenSSL.openssl = nil
+    end
+    
+    it "gives good installation advice on miscellaneous Unixen" do
+      Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
+      expect { Heroku::OpenSSL.ensure_openssl_installed! }.to raise_error(Heroku::OpenSSL::NotInstalledError) { |ex|
+        allow(ex).to receive(:running_on_a_mac?).and_return(false)
+        allow(ex).to receive(:running_on_windows?).and_return(false)
+        expect(ex.installation_hint).to match(/'openssl' package/)
+      }
+      Heroku::OpenSSL.openssl = nil
+    end
+  end
+  
+  describe :CertificateRequest do
+    it "initializes with good defaults" do
+      request = Heroku::OpenSSL::CertificateRequest.new
+      expect(request).not_to be_nil
+      expect(request.key_size).to eq(2048)
+      expect(request.self_signed).to be false
+    end
+    
+    context "generating with self_signed off" do
+      before(:all) do
+        @prev_dir = Dir.getwd
+        @dir = Dir.mktmpdir
+        Dir.chdir @dir
+        
+        request = Heroku::OpenSSL::CertificateRequest.new
+        request.domain = 'example.com'
+        request.subject = '/CN=example.com'
+  
+        # Would like to do this, but the current version of rspec doesn't support it
+        # expect { result = request.generate }.to output.to_stdout_from_any_process
+        @result = request.generate
+      end
+      
+      it "should create Result object" do
+        expect(@result).to be_kind_of Heroku::OpenSSL::CertificateRequest::Result
+      end
+      
+      it "should have a key filename" do
+        expect(@result.key_file).to eq('example.com.key')
+      end
+      
+      it "should have a CSR filename" do
+        expect(@result.csr_file).to eq('example.com.csr')
+      end
+      
+      it "should not have a certificate filename" do
+        expect(@result.crt_file).to be_nil
+      end
+      
+      it "should produce a PEM key file" do
+        expect(File.read(@result.key_file)).to match(/\A-----BEGIN (RSA )?PRIVATE KEY-----\n/)
+      end
+      
+      it "should produce a PEM certificate file" do
+        expect(File.read(@result.csr_file)).to start_with("-----BEGIN CERTIFICATE REQUEST-----\n")
+      end
+      
+      after(:all) do
+        Dir.chdir @prev_dir
+        FileUtils.remove_entry_secure @dir
+      end
+    end
+    
+    context "generating with self_signed on" do
+      before(:all) do
+        @prev_dir = Dir.getwd
+        @dir = Dir.mktmpdir
+        Dir.chdir @dir
+        
+        request = Heroku::OpenSSL::CertificateRequest.new
+        request.domain = 'example.com'
+        request.subject = '/CN=example.com'
+        request.self_signed = true
+  
+        # Would like to do this, but the current version of rspec doesn't support it
+        # expect { result = request.generate }.to output.to_stdout_from_any_process
+        @result = request.generate
+      end
+      
+      it "should create Result object" do
+        expect(@result).to be_kind_of Heroku::OpenSSL::CertificateRequest::Result
+      end
+      
+      it "should have a key filename" do
+        expect(@result.key_file).to eq('example.com.key')
+      end
+      
+      it "should not have a CSR filename" do
+        expect(@result.csr_file).to be_nil
+      end
+      
+      it "should have a certificate filename" do
+        expect(@result.crt_file).to eq('example.com.crt')
+      end
+      
+      it "should produce a PEM key file" do
+        expect(File.read(@result.key_file)).to match(/\A-----BEGIN (RSA )?PRIVATE KEY-----\n/)
+      end
+      
+      it "should produce a PEM certificate file" do
+        expect(File.read(@result.crt_file)).to start_with("-----BEGIN CERTIFICATE-----\n")
+      end
+      
+      after(:all) do
+        Dir.chdir @prev_dir
+        FileUtils.remove_entry_secure @dir
+      end
+    end
+    
+    it "raises installation error when openssl(1) isn't installed" do
+      Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
+      
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          request = Heroku::OpenSSL::CertificateRequest.new
+          request.domain = 'example.com'
+          request.subject = '/CN=example.com'
+      
+          expect { result = request.generate }.to raise_error(Heroku::OpenSSL::NotInstalledError)
+        end
+      end
+      
+      Heroku::OpenSSL.openssl = nil
+    end
+    
+    it "uses key_size to control the key's size" do
+      skip "Can't be tested without an rspec supporting to_stdout_from_any_process" unless RSpec::Matchers::BuiltIn::Output.method_defined? :to_stdout_from_any_process
+      
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          request = Heroku::OpenSSL::CertificateRequest.new
+          request.domain = 'example.com'
+          request.subject = '/CN=example.com'
+          request.key_size = 4096
+      
+          expect { result = request.generate }.to output(/Generating a 4096 bit RSA private key/).to_stdout_from_any_process
+        end
+      end
+    end
+  end
+end

--- a/spec/heroku/open_ssl_spec.rb
+++ b/spec/heroku/open_ssl_spec.rb
@@ -1,6 +1,15 @@
 require "heroku/open_ssl"
 
 describe Heroku::OpenSSL do
+  # This undoes any temporary changes to the property, and also 
+  # resets the flag indicating the path has already been checked.
+  before(:all) do
+    Heroku::OpenSSL.openssl = nil
+  end
+  after(:each) do
+    Heroku::OpenSSL.openssl = nil
+  end
+  
   describe :openssl do
     it "returns 'openssl' when nothing else is set" do
       expect(Heroku::OpenSSL.openssl).to eq("openssl")
@@ -25,12 +34,6 @@ describe Heroku::OpenSSL do
   end
   
   describe :ensure_openssl_installed! do
-    after(:each) do
-      # This undoes any temporary changes to the property, and also 
-      # resets the flag indicating the path has already been checked.
-      Heroku::OpenSSL.openssl = nil
-    end
-    
     it "calls openssl(1) to ensure it's available" do
       expect(Heroku::OpenSSL).to receive(:openssl).with("version").and_return(true)
       Heroku::OpenSSL.ensure_openssl_installed!

--- a/spec/heroku/open_ssl_spec.rb
+++ b/spec/heroku/open_ssl_spec.rb
@@ -25,6 +25,12 @@ describe Heroku::OpenSSL do
   end
   
   describe :ensure_openssl_installed! do
+    after(:each) do
+      # This undoes any temporary changes to the property, and also 
+      # resets the flag indicating the path has already been checked.
+      Heroku::OpenSSL.openssl = nil
+    end
+    
     it "calls openssl(1) to ensure it's available" do
       expect(Heroku::OpenSSL).to receive(:openssl).with("version").and_return(true)
       Heroku::OpenSSL.ensure_openssl_installed!
@@ -37,7 +43,6 @@ describe Heroku::OpenSSL do
     it "detects openssl(1) is absent when it isn't available" do
       Heroku::OpenSSL.openssl = 'openssl-THIS-FILE-SHOULD-NOT-EXIST'
       expect { Heroku::OpenSSL.ensure_openssl_installed! }.to raise_error(Heroku::OpenSSL::NotInstalledError)
-      Heroku::OpenSSL.openssl = nil
     end
     
     it "gives good installation advice on a Mac" do
@@ -47,7 +52,6 @@ describe Heroku::OpenSSL do
         allow(ex).to receive(:running_on_windows?).and_return(false)
         expect(ex.installation_hint).to match(/brew install openssl/)
       }
-      Heroku::OpenSSL.openssl = nil
     end
     
     it "gives good installation advice on Windows" do
@@ -57,7 +61,6 @@ describe Heroku::OpenSSL do
         allow(ex).to receive(:running_on_windows?).and_return(true)
         expect(ex.installation_hint).to match(/Win32OpenSSL\.html/)
       }
-      Heroku::OpenSSL.openssl = nil
     end
     
     it "gives good installation advice on miscellaneous Unixen" do
@@ -67,7 +70,6 @@ describe Heroku::OpenSSL do
         allow(ex).to receive(:running_on_windows?).and_return(false)
         expect(ex.installation_hint).to match(/'openssl' package/)
       }
-      Heroku::OpenSSL.openssl = nil
     end
   end
   


### PR DESCRIPTION
Reverts the reversion of my previous pull request to add a `certs:generate` command, and integrates a fix for the flaky `ensure_openssl_installed!` test that caused tests to sometimes fail.