### PR TITLE
Fix bug in extract_app_in_dir when getting remote

### DIFF
--- a/lib/heroku/command/base.rb
+++ b/lib/heroku/command/base.rb
@@ -218,7 +218,7 @@ protected
     if remote = options[:remote]
       remotes[remote]
     elsif remote = extract_app_from_git_config
-      remotes[remote]
+      remote
     else
       apps = remotes.values.uniq
       if apps.size == 1

--- a/spec/heroku/command/base_spec.rb
+++ b/spec/heroku/command/base_spec.rb
@@ -93,6 +93,12 @@ other\tgit@other.com:other.git (push)
         expect(@base.app).to eq('example')
       end
 
+      it "get the app from git config" do
+        allow(@base).to receive(:git_remotes).and_return('')
+        allow(@base).to receive(:git).with('config heroku.remote').and_return("example")
+        expect(@base.app).to eq('example')
+      end
+
       it "accepts a --remote argument to choose the app from the remote name" do
         allow(@base).to receive(:git_remotes).and_return({ 'staging' => 'example-staging', 'production' => 'example' })
         allow(@base).to receive(:options).and_return(:remote => "staging")


### PR DESCRIPTION
Sometimes, heroku client cannot find the remote app even when it's been added to git config. This fixes it.

**Case:**

```bash
git remote add heroku git@heroku.com:yourapp.git

# OR
heroku git:remote -a yourapp
```

```bash
# .git/config
[remote "heroku"]
	url = https://git.heroku.com/yourapp.git
	fetch = +refs/heads/*:refs/remotes/heroku/*
```

```bash
$ heroku logs
!    No app specified.
!    Run this command from an app folder or specify which app to use with --app APP.
```
