### PR TITLE
Allow use of remote source if URI is specified as database.

### DIFF
--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -276,5 +276,19 @@ STDOUT
       end
     end
 
+    describe '#parse_db_url' do
+      it 'returns a local url when only database name is supplied' do
+        pg = Heroku::Command::Pg.new
+        parsed_url = pg.send(:parse_db_url, 'MyLocalDb')
+        expect(parsed_url).to eql 'postgres:///MyLocalDb'
+      end
+
+      it 'returns the original path when a url is specified' do
+        url = 'postgres://user:password@server:1234/'.freeze
+        pg = Heroku::Command::Pg.new
+        parsed_url = pg.send(:parse_db_url, url)
+        expect(parsed_url).to eql url
+      end
+    end
   end
 end


### PR DESCRIPTION
Enable pushing to / pulling from a remote postgres server when a full connection url is passed as the local database parameter instead of just a database name.

This was required in order to perform automated deploys from a Dockerized jenkins instance with a linked postgres Docker container where the containers are running on the same docker host, but the database connection must occur via the linked container's virtual IP and the database is not accessible on the jenkins server via `localhost`.