### PR TITLE
Fix remote push pull

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -322,7 +322,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
       exit(1)
     end
 
-    target_uri = generate_resolver.resolve(remote).url
+    target_uri = resolve_heroku_url(remote)
     source_uri = parse_db_url(local)
 
     pgdr = PgDumpRestore.new(
@@ -349,12 +349,12 @@ class Heroku::Command::Pg < Heroku::Command::Base
       exit(1)
     end
 
-    source_uri = generate_resolver.resolve(remote).url
+    source_uri = resolve_heroku_url(remote)
     target_uri = parse_db_url(local)
 
     pgdr = PgDumpRestore.new(
-      target_uri,
       source_uri,
+      target_uri,
       self)
 
     pgdr.execute
@@ -454,6 +454,10 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
 
 private
+
+  def resolve_heroku_url(remote)
+    generate_resolver.resolve(remote).url
+  end
 
   def generate_resolver
     app_name = app rescue nil # will raise if no app, but calling app reads in arguments

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -276,5 +276,19 @@ STDOUT
       end
     end
 
+    describe '#parse_db_url' do
+      it 'returns a local url when only database name is supplied' do
+        pg = Heroku::Command::Pg.new
+        parsed_url = pg.send(:parse_db_url, 'MyLocalDb')
+        expect(parsed_url).to eql 'postgres:///MyLocalDb'
+      end
+
+      it 'returns the original path when a url is specified' do
+        url = 'postgres://user:password@server:1234/'.freeze
+        pg = Heroku::Command::Pg.new
+        parsed_url = pg.send(:parse_db_url, url)
+        expect(parsed_url).to eql url
+      end
+    end
   end
 end

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -276,6 +276,66 @@ STDOUT
       end
     end
 
+    describe '#push' do
+      context 'with remote and local dbs specified' do
+        let(:remote) { 'MY_HEROKU_DB_FUSCIA' }
+        let(:local)  { 'MyLocalDb' }
+
+        it 'executes dump restore with correct targets' do
+          pg          = Heroku::Command::Pg.new
+          remote_url  = "postgres://someurl.test/#{remote}"
+          local_url   = "postgres:///#{local}"
+          dump_restore = double()
+          expect(pg).to receive(:resolve_heroku_url).and_return(remote_url)
+          expect(dump_restore).to receive(:execute)
+          expect(Heroku::Command).to receive(:shift_argument).and_return(local, remote)
+          expect(PgDumpRestore).to receive(:new).with(local_url, remote_url, pg).and_return(dump_restore)
+
+          pg.push
+        end
+      end
+
+      context 'with no databases specified' do
+        it 'displays help' do
+          pg = Heroku::Command::Pg.new
+          expect(pg).to receive(:current_command).and_return('push')
+          expect(Heroku::Command).to receive(:run).with('push', ['--help'])
+
+          expect { pg.push }.to raise_error SystemExit
+        end
+      end
+    end
+
+    describe '#pull' do
+      context 'with remote and local dbs specified' do
+        let(:remote) { 'MY_HEROKU_DB_FUSCIA' }
+        let(:local)  { 'MyLocalDb' }
+
+        it 'executes dump restore with correct targets' do
+          pg          = Heroku::Command::Pg.new
+          remote_url  = "postgres://someurl.test/#{remote}"
+          local_url   = "postgres:///#{local}"
+          dump_restore = double()
+          expect(pg).to receive(:resolve_heroku_url).and_return(remote_url)
+          expect(dump_restore).to receive(:execute)
+          expect(Heroku::Command).to receive(:shift_argument).and_return(remote, local)
+          expect(PgDumpRestore).to receive(:new).with(remote_url, local_url, pg).and_return(dump_restore)
+
+          pg.pull
+        end
+
+        context 'with no databases specified' do
+          it 'displays help' do
+            pg = Heroku::Command::Pg.new
+            expect(pg).to receive(:current_command).and_return('pull')
+            expect(Heroku::Command).to receive(:run).with('pull', ['--help'])
+
+            expect { pg.pull }.to raise_error SystemExit
+          end
+        end
+      end
+    end
+
     describe '#parse_db_url' do
       it 'returns a local url when only database name is supplied' do
         pg = Heroku::Command::Pg.new


### PR DESCRIPTION
@dickeyxxx 

This fixes the earlier bug.  The local & remote url argument order when calling PgDumpRestore for `pull` accidentally got reversed during refactor/renaming.  This PR adds unit tests around pg `#push` and `#pull` methods.