### PR TITLE
Updated help text for 2fa in two_factor.rb

### DIFF
--- a/lib/heroku/command/two_factor.rb
+++ b/lib/heroku/command/two_factor.rb
@@ -1,12 +1,12 @@
 require "heroku/command/base"
 
-# manage two factor settings for account
-#
 module Heroku::Command
+  # manage two-factor authentication settings for your account
+  #
   class TwoFactor < BaseWithApp
     # 2fa
     #
-    # Display whether two-factor is enabled or not
+    # Display whether two-factor authentication is enabled or not
     #
     def index
       account = api.request(
@@ -16,9 +16,9 @@ module Heroku::Command
         :path    => "/account").body
 
       if account["two_factor_authentication"]
-        display "Two-factor auth is enabled."
+        display "Two-factor authentication is enabled."
       else
-        display "Two-factor is not enabled."
+        display "Two-factor authentication is not enabled."
       end
     end
 
@@ -26,7 +26,7 @@ module Heroku::Command
 
     # 2fa:disable
     #
-    # Disable 2fa on your account
+    # Disable two-factor authentication for your account
     #
     def disable
       print "Password (typing will be hidden): "
@@ -52,7 +52,7 @@ module Heroku::Command
 
     # 2fa:generate-recovery-codes
     #
-    # Generates (and replaces) recovery codes
+    # Generates and replaces recovery codes
     #
     def generate_recovery_codes
       code = Heroku::Auth.ask_for_second_factor

--- a/lib/heroku/command/two_factor.rb
+++ b/lib/heroku/command/two_factor.rb
@@ -1,10 +1,10 @@
 require "heroku/command/base"
 
 module Heroku::Command
-  # manage two-factor authentication settings for your account
+  # manage two-factor authentication settings
   #
   class TwoFactor < BaseWithApp
-    # 2fa
+    # twofactor
     #
     # Display whether two-factor authentication is enabled or not
     #
@@ -24,7 +24,7 @@ module Heroku::Command
 
     alias_command "2fa", "twofactor"
 
-    # 2fa:disable
+    # twofactor:disable
     #
     # Disable two-factor authentication for your account
     #
@@ -50,7 +50,7 @@ module Heroku::Command
     alias_command "2fa:disable", "twofactor:disable"
 
 
-    # 2fa:generate-recovery-codes
+    # twofactor:generate-recovery-codes
     #
     # Generates and replaces recovery codes
     #


### PR DESCRIPTION
Edited the CLI help text for the twofactor command and moved the first comment directly before the definition of the TwoFactor class to resolve the issue that the main help text for the twofactor command was missing:
  ```
  stack           #  manage the stack for an app
  status          #  check status of heroku platform
  twofactor       #                   
  update          #  update the heroku client
  version         #  display version
```

I did not test this fix so please double check that everything is ok before you merge it.