### PR TITLE
Add a buildpack command

### DIFF
--- a/lib/heroku/api/apps_v3.rb
+++ b/lib/heroku/api/apps_v3.rb
@@ -1,0 +1,27 @@
+module Heroku
+  class API
+    def get_app_buildpacks_v3(app)
+      headers = { 'Accept' => 'application/vnd.heroku+json; version=3' }
+      request(
+      :expects  => [ 200, 206 ],
+      :headers  => headers,
+      :method   => :get,
+      :path     => "/apps/#{app}/buildpack-installations"
+      )
+    end
+
+    def put_app_buildpacks_v3(app, body={})
+      headers = {
+        'Accept'       => 'application/vnd.heroku+json; version=3',
+        'Content-Type' => 'application/json'
+      }
+      request(
+      :expects  => 200,
+      :headers  => headers,
+      :method   => :put,
+      :path     => "/apps/#{app}/buildpack-installations",
+      :body     => Heroku::Helpers.json_encode(body)
+      )
+    end
+  end
+end

--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -267,8 +267,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
       end
 
       if buildpack = options[:buildpack]
-        api.put_config_vars(info["name"], "BUILDPACK_URL" => buildpack)
-        display("BUILDPACK_URL=#{buildpack}")
+        api.put_app_buildpacks_v3(info['name'], {:updates => [{:buildpack => buildpack}]})
+        display "Buildpack set. Next release on #{info['name']} will use #{buildpack}."
       end
 
       hputs([ info["web_url"], git_url(info['name']) ].join(" | "))

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -40,7 +40,7 @@ module Heroku::Command
 
       api.put_app_buildpacks_v3(app, {:updates => [{:buildpack => buildpack_url}]})
       display "Buildpack set. Next release on #{app} will use #{buildpack_url}."
-      display "Run `git push heroku master` to create a new release on #{buildpack_url}."
+      display "Run `git push heroku master` to create a new release using #{buildpack_url}."
     end
 
     # buildpack:unset

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -49,7 +49,17 @@ module Heroku::Command
     #
     def unset
       api.put_app_buildpacks_v3(app, {:updates => []})
-      display "Buildpack unset. Next release on #{app} will detect buildpack normally."
+
+      vars = api.get_config_vars(app).body
+      if vars.has_key?("BUILDPACK_URL")
+        display "Buildpack unset."
+        warn "WARNING: The BUILDPACK_URL config var is still set and will be used for the next release"
+      elsif vars.has_key?("LANGUAGE_PACK_URL")
+        display "Buildpack unset."
+        warn "WARNING: The LANGUAGE_PACK_URL config var is still set and will be used for the next release"
+      else
+        display "Buildpack unset. Next release on #{app} will detect buildpack normally."
+      end
     end
 
   end

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -38,7 +38,7 @@ module Heroku::Command
         error("Usage: heroku buildpack:set BUILDPACK_URL.\nMust specify target buildpack URL.")
       end
 
-      api.put_app_buildpacks_v3(app, {updates: [{buildpack: buildpack_url}]})
+      api.put_app_buildpacks_v3(app, {:updates => [{:buildpack => buildpack_url}]})
       display "Buildpack set. Next release on #{app} will use #{buildpack_url}."
       display "Run `git push heroku master` to create a new release on #{buildpack_url}."
     end
@@ -48,7 +48,7 @@ module Heroku::Command
     # unset the app buildpack
     #
     def unset
-      api.put_app_buildpacks_v3(app, {updates: []})
+      api.put_app_buildpacks_v3(app, {:updates => []})
       display "Buildpack unset. Next release on #{app} will detect buildpack normally."
     end
 

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -1,0 +1,56 @@
+require "heroku/command/base"
+require "heroku/api/apps_v3"
+
+module Heroku::Command
+
+  # manage the buildpack for an app
+  #
+  class Buildpack < Base
+
+    # buildpack
+    #
+    # display the buildpack_url for an app
+    #
+    #Examples:
+    #
+    # $ heroku buildpack
+    # https://github.com/heroku/heroku-buildpack-ruby
+    #
+    def index
+      validate_arguments!
+
+      app_buildpacks = api.get_app_buildpacks_v3(app)[:body]
+
+      if app_buildpacks.nil? or app_buildpacks.empty?
+        display("#{app} has no Buildpack URL set.")
+      else
+        styled_header("#{app} Buildpack URL")
+        display(app_buildpacks.first["buildpack"]["url"])
+      end
+    end
+
+    # buildpack:set BUILDPACK_URL
+    #
+    # set new app buildpack
+    #
+    def set
+      unless buildpack_url = shift_argument
+        error("Usage: heroku buildpack:set BUILDPACK_URL.\nMust specify target buildpack URL.")
+      end
+
+      api.put_app_buildpacks_v3(app, {updates: [{buildpack: buildpack_url}]})
+      display "Buildpack set. Next release on #{app} will use #{buildpack_url}."
+      display "Run `git push heroku master` to create a new release on #{buildpack_url}."
+    end
+
+    # buildpack:unset
+    #
+    # unset the app buildpack
+    #
+    def unset
+      api.put_app_buildpacks_v3(app, {updates: []})
+      display "Buildpack unset. Next release on #{app} will detect buildpack normally."
+    end
+
+  end
+end

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -136,12 +136,13 @@ STDOUT
       end
 
       it "with a buildpack" do
+        Excon.stub({:method => :put, :path => "/apps/buildpackapp/buildpack-installations"}, {:status => 200})
         with_blank_git_repository do
           stderr, stdout = execute("apps:create buildpackapp --buildpack http://example.org/buildpack.git")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Creating buildpackapp... done, stack is bamboo-mri-1.9.2
-BUILDPACK_URL=http://example.org/buildpack.git
+Buildpack set. Next release on buildpackapp will use http://example.org/buildpack.git.
 http://buildpackapp.herokuapp.com/ | https://git.heroku.com/buildpackapp.git
 Git remote heroku added
 STDOUT

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -81,6 +81,28 @@ Run `git push heroku master` to create a new release using https://github.com/he
 Buildpack unset. Next release on example will detect buildpack normally.
         STDOUT
       end
+
+      it "unsets and warns about buildpack URL config var" do
+        execute("config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
+        stderr, stdout = execute("buildpack:unset")
+        expect(stderr).to eq <<-STDERR
+WARNING: The BUILDPACK_URL config var is still set and will be used for the next release
+        STDERR
+        expect(stdout).to eq <<-STDOUT
+Buildpack unset.
+        STDOUT
+      end
+
+      it "unsets and warns about language pack URL config var" do
+        execute("config:set LANGUAGE_PACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
+        stderr, stdout = execute("buildpack:unset")
+        expect(stderr).to eq <<-STDERR
+WARNING: The LANGUAGE_PACK_URL config var is still set and will be used for the next release
+        STDERR
+        expect(stdout).to eq <<-STDOUT
+Buildpack unset.
+        STDOUT
+      end
     end
   end
 end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+require "heroku/command/buildpack"
+
+module Heroku::Command
+  describe Buildpack do
+
+    before(:each) do
+      stub_core
+      api.post_app("name" => "example", "stack" => "cedar-14")
+
+      Excon.stub({:method => :put, :path => "/apps/example/buildpack-installations"},
+        {:status => 200})
+      Excon.stub({:method => :get, :path => "/apps/example/buildpack-installations"},
+        {
+          :body => [{"buildpack" => { "url" => "https://github.com/heroku/heroku-buildpack-ruby"}}],
+          :status => 200
+        })
+    end
+
+    after(:each) do
+      Excon.stubs.shift
+      Excon.stubs.shift
+      api.delete_app("example")
+    end
+
+    describe "index" do
+      it "displays the buildpack URL" do
+        stderr, stdout = execute("buildpack")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+=== example Buildpack URL
+https://github.com/heroku/heroku-buildpack-ruby
+        STDOUT
+      end
+
+      context "with no buildpack URL set" do
+        before(:each) do
+          Excon.stubs.shift
+          Excon.stub({:method => :get, :path => "/apps/example/buildpack-installations"},
+            {
+            :body => [],
+            :status => 200
+            })
+        end
+
+        it "does not display a buildpack URL" do
+          stderr, stdout = execute("buildpack")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+example has no Buildpack URL set.
+          STDOUT
+        end
+      end
+    end
+
+    describe "set" do
+      it "sets the buildpack URL" do
+        stderr, stdout = execute("buildpack:set https://github.com/heroku/heroku-buildpack-ruby")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
+Run `git push heroku master` to create a new release on https://github.com/heroku/heroku-buildpack-ruby.
+        STDOUT
+      end
+
+      it "handles a missing buildpack URL arg" do
+        stderr, stdout = execute("buildpack:set")
+        expect(stderr).to eq <<-STDERR
+ !    Usage: heroku buildpack:set BUILDPACK_URL.
+ !    Must specify target buildpack URL.
+        STDERR
+        expect(stdout).to eq("")
+      end
+    end
+
+    describe "unset" do
+      it "unsets the buildpack URL" do
+        stderr, stdout = execute("buildpack:unset")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+Buildpack unset. Next release on example will detect buildpack normally.
+        STDOUT
+      end
+    end
+  end
+end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -59,7 +59,7 @@ example has no Buildpack URL set.
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
-Run `git push heroku master` to create a new release on https://github.com/heroku/heroku-buildpack-ruby.
+Run `git push heroku master` to create a new release using https://github.com/heroku/heroku-buildpack-ruby.
         STDOUT
       end
 


### PR DESCRIPTION
Added a buildpack command for setting and unsetting buildpack urls as first class attributes of an App. This new command requires the v3 API for app. As a result an app_v3.rb file has been created in the same pattern as used by the fork command.

Added an index, set and unset methods for buildpack command. This displays the currently set buildpack URL or displays a message that no buildpack URL has been set.

In order to avoid confusion with the existing ["buildpacks" toolbelt plugin](https://github.com/heroku/heroku-buildpacks), I will rename that plugin to "buildkits" (pending approval from @craigkerstiens)
