### PR TITLE
Update jsplugin.rb

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -115,6 +115,8 @@ class Heroku::JSPlugin
       "linux"
     when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
       "windows"
+    when /openbsd/
+      "openbsd"
     else
       raise "unsupported on #{RUBY_PLATFORM}"
     end


### PR DESCRIPTION
On OpenBSD I had this error:

$ heroku run rake db:migrate
 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new
$ less /home/vtamara/.heroku/error.log 
Heroku client internal error.
unsupported on x86_64-openbsd
/home/vtamara/.heroku/client/lib/heroku/jsplugin.rb:119:in `os'
/home/vtamara/.heroku/client/lib/heroku/jsplugin.rb:79:in `bin'
/home/vtamara/.heroku/client/lib/heroku/jsplugin.rb:5:in `setup?'
/home/vtamara/.heroku/client/lib/heroku/jsplugin.rb:9:in `load!'
/home/vtamara/.heroku/client/lib/heroku/command.rb:18:in `load'
/home/vtamara/.heroku/client/lib/heroku/cli.rb:39:in `start'
/usr/local/heroku/bin/heroku:24:in `<main>'


After this simple patch, "heroku run rake db:migrate" works.