### PR TITLE
Fixed OS checking on Arch Linux using JRuby

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -108,7 +108,7 @@ class Heroku::JSPlugin
   end
 
   def self.os
-    case RUBY_PLATFORM
+    case RbConfig::CONFIG['host_os']
     when /darwin|mac os/
       "darwin"
     when /linux/


### PR DESCRIPTION
Changed the operating system test to use a more relevant source. When using JRuby,
RAILS_PLATFORM will return "java" which is not relevant to the test.

Switched to RbConfig, a more reliable method for this.