### PR TITLE
full_host doesn't require an arg, use full_host_uri.host for checking netrc.

### DIFF
--- a/lib/heroku/client/organizations.rb
+++ b/lib/heroku/client/organizations.rb
@@ -212,7 +212,7 @@ class Heroku::Client::Organizations
     end
 
     def manager_url
-      Heroku::Auth.full_host(Heroku::Auth.host)
+      Heroku::Auth.full_host
     end
 
   end


### PR DESCRIPTION
Lets something like this work with proper checking of netrc:

```sh-session
$ HEROKU_HOST=https://somewhere-else.com heroku apps
```