### PR TITLE
Relax the version requirement for MultiJson.

### DIFF
--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "netrc",          ">= 0.10.0"
   gem.add_dependency "rest-client",    "= 1.6.7"
   gem.add_dependency "rubyzip",        "= 0.9.9"
-  gem.add_dependency "multi_json",     "~> 1.10.1"
+  gem.add_dependency "multi_json",     "~> 1.10"
 end

--- a/lib/heroku/command/two_factor.rb
+++ b/lib/heroku/command/two_factor.rb
@@ -32,7 +32,7 @@ module Heroku::Command
       print "Password (typing will be hidden): "
       password = Heroku::Auth.ask_for_password
 
-      update = MultiJson.encode(
+      update = MultiJson.dump(
         :two_factor_authentication => false,
         :password => password)
 


### PR DESCRIPTION
Firstly I am trying to update the dependencies on a Rails app and
bundler is attempting to downgrade the heroku gem due to an update
for `multi_json`.

Secondly it appears that the gem is using `MultiJson.dump` and
`MultiJson.load` exclusively (`MultiJson.encode` is an alias to `dump`).
These methods have been the public API since 1.6.0 with no discussion
that I could find about changing them. Considering the surface area
being used of MultiJson and that it's an incredibly common dependency it
seems unnecessary to lock to to a specific micro version.

Finally this replaces the one use of `MultiJson.encode` with
`MultiJson.dump` which is the more common usage in the code.