### PR TITLE
Properly escape shell variables in config -s

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -1,4 +1,6 @@
 require "heroku/command/base"
+require "shellwords"
+
 
 # manage app config vars
 #
@@ -40,7 +42,7 @@ class Heroku::Command::Config < Heroku::Command::Base
       vars.each {|key, value| vars[key] = value.to_s}
       if options[:shell]
         vars.keys.sort.each do |key|
-          display(%{#{key}=#{vars[key]}})
+          display(%{#{key}=#{Shellwords.shellescape vars[key]}})
         end
       else
         styled_header("#{app} Config Vars")

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -56,12 +56,13 @@ STDOUT
     end
 
     it "shows configs in a shell compatible format" do
-      api.put_config_vars("example", { 'A' => 'one', 'B' => 'two three' })
+      api.put_config_vars("example", { 'A' => 'one', 'B' => 'two three', 'C' => "foo&bar" })
       stderr, stdout = execute("config --shell")
       expect(stderr).to eq("")
       expect(stdout).to eq <<-STDOUT
 A=one
-B=two three
+B=two\\ three
+C=foo\\&bar
 STDOUT
     end
 


### PR DESCRIPTION
Fixes #876 

### Steps to reproduce:

Load a json into a var:

settings.json:
```json
{
  "foo": "bar",
  "cow": "baz"
}
```

```bash
heroku config:set APP_SETTINGS=`cat settings.json`
```

Load all vars into shell:

```bash
eval `heroku config -s`
```

### Result:

```
foo:: command not found
```