### PR TITLE
Postgres backups cleanup and fixes

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -397,8 +397,14 @@ EOF
     end
 
     url_info = client.transfers_public_url(backup_num)
-    $stderr.puts "The following URL will expire at #{url_info[:expires_at]}:"
-    display url_info[:url]
+    if $stdout.tty?
+      display <<-EOF
+The following URL will expire at #{url_info[:expires_at]}:
+  "#{url_info[:url]}"
+EOF
+    else
+      display url_info[:url]
+    end
   end
 
   def cancel_backup

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -224,8 +224,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
            else
              "Manual"
            end
-    orig_size = backup[:source_bytes]
     backup_size = backup[:processed_bytes]
+    orig_size = backup[:source_bytes] || backup_size
+
     compression_pct = [((orig_size - backup_size).to_f / orig_size * 100).round, 0].max
     display <<-EOF
 === Backup info: #{backup_id}

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -112,13 +112,13 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
   def size_pretty(bytes)
-    suffixes = {
-      'B'  => 1,
-      'kB' => 1_000,
-      'MB' => 1_000_000,
-      'GB' => 1_000_000_000,
-      'TB' => 1_000_000_000_000 # (ohdear)
-    }
+    suffixes = [
+      ['B', 1],
+      ['kB', 1_000],
+      ['MB', 1_000_000],
+      ['GB', 1_000_000_000],
+      ['TB', 1_000_000_000_000] # (ohdear)
+    ]
     suffix, multiplier = suffixes.find do |k,v|
       normalized = bytes / v.to_f
       normalized >= 0 && normalized < 1_000

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -96,7 +96,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
   def backup_num(transfer_name)
-    /b(\d+)/.match(transfer_name) && $1
+    /b(\d+)/.match(transfer_name) && $1.to_i
   end
 
   def transfer_status(t)
@@ -199,6 +199,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
                if last_backup.nil?
                  error("No backups. Capture one with `heroku pg:backups capture`.")
                else
+                 backup_id = transfer_name(last_backup[:num])
                  if verbose
                    client.transfers_get(last_backup[:num], verbose)
                  else

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -233,14 +233,20 @@ Backup Size:      #{backup_size}.0B (50% compression)
 
       it "gets a public url for the specified backup" do
         stderr, stdout = execute("pg:backups public-url b001")
+        expect(stdout).to include url1_info[:url]
+        expect(stdout).to match(/will expire at #{Regexp.quote(url1_info[:expires_at].to_s)}/)
+      end
+
+      it "only prints the url if stdout is not a tty" do
+        fake_stdout = StringIO.new
+        stderr, stdout = execute("pg:backups public-url b001", { stdout: fake_stdout })
         expect(stdout.chomp).to eq url1_info[:url]
-        expect(stderr).to match(/will expire at #{Regexp.quote(url1_info[:expires_at].to_s)}/)
       end
 
       it "defaults to the latest backup if none is specified" do
         stderr, stdout = execute("pg:backups public-url")
-        expect(stdout.chomp).to eq url2_info[:url]
-        expect(stderr).to match(/will expire at #{Regexp.quote(url2_info[:expires_at].to_s)}/)
+        expect(stdout).to include url2_info[:url]
+        expect(stdout).to match(/will expire at #{Regexp.quote(url2_info[:expires_at].to_s)}/)
       end
     end
   end

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+require "heroku/command/pg"
+require "heroku/command/pg_backups"
+
+module Heroku::Command
+  describe Pg do
+    let(:ivory_url) { 'postgres:///database_url' }
+    let(:green_url) { 'postgres:///green_database_url' }
+    let(:red_url)   { 'postgres:///red_database_url' }
+
+    let(:teal_url)  { 'postgres:///teal_database_url' }
+
+    let(:example_attachments) do
+      [
+          Heroku::Helpers::HerokuPostgresql::Attachment.new({
+            'app' => {'name' => 'example'},
+            'name' => 'HEROKU_POSTGRESQL_IVORY',
+            'config_var' => 'HEROKU_POSTGRESQL_IVORY_URL',
+            'resource' => {'name'  => 'loudly-yelling-1232',
+                           'value' => ivory_url,
+                           'type'  => 'heroku-postgresql:standard-0' }}),
+          Heroku::Helpers::HerokuPostgresql::Attachment.new({
+            'app' => {'name' => 'example'},
+            'name' => 'HEROKU_POSTGRESQL_GREEN',
+            'config_var' => 'HEROKU_POSTGRESQL_GREEN_URL',
+            'resource' => {'name'  => 'softly-mocking-123',
+                           'value' => green_url,
+                           'type'  => 'heroku-postgresql:standard-0' }}),
+          Heroku::Helpers::HerokuPostgresql::Attachment.new({
+            'app' => {'name' => 'example'},
+            'name' => 'HEROKU_POSTGRESQL_RED',
+            'config_var' => 'HEROKU_POSTGRESQL_RED_URL',
+            'resource' => {'name'  => 'whatever-something-2323',
+                           'value' => red_url,
+                           'type'  => 'heroku-postgresql:standard-0' }})
+      ]
+    end
+
+    let(:aux_example_attachments) do
+      [
+          Heroku::Helpers::HerokuPostgresql::Attachment.new({
+            'app' => {'name' => 'aux-example'},
+            'name' => 'HEROKU_POSTGRESQL_TEAL',
+            'config_var' => 'HEROKU_POSTGRESQL_TEAL_URL',
+            'resource' => {'name'  => 'loudly-yelling-1232',
+                           'value' => teal_url,
+                           'type'  => 'heroku-postgresql:standard-0' }})
+      ]
+    end
+
+    before do
+      stub_core
+
+      api.post_app "name" => "example"
+      api.put_config_vars "example", {
+        "DATABASE_URL" => "postgres://database_url",
+        "HEROKU_POSTGRESQL_IVORY_URL" => ivory_url,
+        "HEROKU_POSTGRESQL_GREEN_URL" => green_url,
+        "HEROKU_POSTGRESQL_RED_URL" => red_url,
+      }
+
+      api.post_app "name" => "aux-example"
+      api.put_config_vars "aux-example", {
+        "DATABASE_URL" => "postgres://database_url",
+        "HEROKU_POSTGRESQL_TEAL_URL" => teal_url
+      }
+    end
+
+    after do
+      api.delete_app "aux-example"
+      api.delete_app "example"
+    end
+
+    describe "heroku pg:copy" do
+      let(:copy_info) do
+        { :uuid => 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+         :from_type => 'pg_dump', :to_type => 'pg_restore',
+         :started_at => Time.now, :finished_at => Time.now,
+         :processed_bytes => 42, :succeeded => true }
+      end
+
+      before do
+        # hideous hack because we can't do dependency injection
+        orig_new = Heroku::Helpers::HerokuPostgresql::Resolver.method(:new)
+        allow(Heroku::Helpers::HerokuPostgresql::Resolver).to receive(:new) do |app_name, api|
+          resolver = orig_new.call(app_name, api)
+          allow(resolver).to receive(:app_attachments) do
+            if resolver.app_name == 'example'
+              example_attachments
+            else
+              aux_example_attachments
+            end
+          end
+          resolver
+        end
+      end
+
+      it "copies data from one database to another" do
+        stub_pg.pg_copy('IVORY', ivory_url, 'RED', red_url).returns(copy_info)
+        stub_pgapp.transfers_get.returns(copy_info)
+
+        stderr, stdout = execute("pg:copy ivory red --confirm example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/Copy completed/)
+      end
+
+      it "does not copy without confirmation" do
+        stderr, stdout = execute("pg:copy ivory red")
+        expect(stderr).to match(/Confirmation did not match example. Aborted./)
+        expect(stdout).to match(/WARNING: Destructive Action/)
+        expect(stdout).to match(/This command will affect the app: example/)
+        expect(stdout).to match(/To proceed, type "example" or re-run this command with --confirm example/)
+      end
+
+      it "copies across apps" do
+        stub_pg.pg_copy('TEAL', teal_url, 'RED', red_url).returns(copy_info)
+        stub_pgapp.transfers_get.returns(copy_info)
+
+        stderr, stdout = execute("pg:copy aux-example::teal red --confirm example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/Copy completed/)
+      end
+    end
+  end
+end

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -234,13 +234,13 @@ Backup Size:      #{backup_size}.0B (50% compression)
       it "gets a public url for the specified backup" do
         stderr, stdout = execute("pg:backups public-url b001")
         expect(stdout.chomp).to eq url1_info[:url]
-        expect(stderr).to match(/will expire at #{url1_info[:expires_at]}/)
+        expect(stderr).to match(/will expire at #{Regexp.quote(url1_info[:expires_at].to_s)}/)
       end
 
       it "defaults to the latest backup if none is specified" do
         stderr, stdout = execute("pg:backups public-url")
         expect(stdout.chomp).to eq url2_info[:url]
-        expect(stderr).to match(/will expire at #{url2_info[:expires_at]}/)
+        expect(stderr).to match(/will expire at #{Regexp.quote(url2_info[:expires_at].to_s)}/)
       end
     end
   end

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -239,7 +239,7 @@ Backup Size:      #{backup_size}.0B (50% compression)
 
       it "only prints the url if stdout is not a tty" do
         fake_stdout = StringIO.new
-        stderr, stdout = execute("pg:backups public-url b001", { stdout: fake_stdout })
+        stderr, stdout = execute("pg:backups public-url b001", { :stdout => fake_stdout })
         expect(stdout.chomp).to eq url1_info[:url]
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,16 @@ def stub_pg
   end
 end
 
+def stub_pgapp
+  @stubbed_pgapp ||= begin
+    stubbed_pgapp = nil
+    any_instance_of(Heroku::Client::HerokuPostgresqlApp) do |pg|
+      stubbed_pgapp = stub(pg)
+    end
+    stubbed_pgapp
+  end
+end
+
 def stub_pgbackups
   @stubbed_pgbackups ||= begin
     stubbed_pgbackups = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ def prepare_command(klass)
   command
 end
 
-def execute(command_line)
+def execute(command_line, opts={})
   extend RR::Adapters::RRMethods
 
   args = command_line.split(" ")
@@ -60,14 +60,16 @@ def execute(command_line)
 
   original_stdin, original_stderr, original_stdout = $stdin, $stderr, $stdout
 
-  $stdin  = captured_stdin  = StringIO.new
-  $stderr = captured_stderr = StringIO.new
-  $stdout = captured_stdout = StringIO.new
-  class << captured_stdout
+  fake_tty_stdout = StringIO.new
+  class << fake_tty_stdout
     def tty?
       true
     end
   end
+
+  $stdin  = captured_stdin  = opts.fetch(:stdin, StringIO.new)
+  $stderr = captured_stderr = opts.fetch(:stderr, StringIO.new)
+  $stdout = captured_stdout = opts.fetch(:stdout, fake_tty_stdout)
 
   begin
     object.send(method)


### PR DESCRIPTION
This resolves a few edge cases, makes the argument to `heroku pg:backups public-url` optional (defaults to last successful backup), and moves auxiliary output of `heroku pg:backups public-url` to stderr so that stdout output can be used directly in another command.

It also adds some (long-overdue) tests.