### PR TITLE
Rename cedar => cedar-10 in help text

### DIFF
--- a/lib/heroku/command/stack.rb
+++ b/lib/heroku/command/stack.rb
@@ -13,7 +13,7 @@ module Heroku::Command
     #
     # $ heroku stack
     # === example Available Stacks
-    #   cedar
+    #   cedar-10
     # * cedar-14
     #
     def index


### PR DESCRIPTION
Missed this while renaming. Didn't realize the doc part was extracted into the help text.

Thanks for noticing @friism 