### PR TITLE
Update rubyzip dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       multi_json (~> 1.10)
       netrc (>= 0.10.0)
       rest-client (= 1.6.7)
-      rubyzip (= 0.9.9)
+      rubyzip (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -56,7 +56,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    rubyzip (0.9.9)
+    rubyzip (1.1.7)
     safe_yaml (1.0.4)
     simplecov (0.9.2)
       docile (~> 1.1.0)

--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "launchy",        ">= 0.3.2"
   gem.add_dependency "netrc",          ">= 0.10.0"
   gem.add_dependency "rest-client",    "= 1.6.7"
-  gem.add_dependency "rubyzip",        "= 0.9.9"
+  gem.add_dependency "rubyzip",        "~> 1.0"
   gem.add_dependency "multi_json",     "~> 1.10"
 end

--- a/lib/heroku/updater.rb
+++ b/lib/heroku/updater.rb
@@ -107,7 +107,7 @@ module Heroku
       stderr_print 'updating...'
       wait_for_lock do
         require "tmpdir"
-        require "zip/zip"
+        require "zip"
 
         Dir.mktmpdir do |download_dir|
           zip_filename = "#{download_dir}/heroku.zip"
@@ -148,11 +148,11 @@ module Heroku
     end
 
     def self.extract_zip(filename, dir)
-      Zip::ZipFile.open(filename) do |zip|
+      Zip::File.open(filename) do |zip|
         zip.each do |entry|
           target = File.join(dir, entry.to_s)
           FileUtils.mkdir_p File.dirname(target)
-          zip.extract(entry, target) { true }
+          entry.extract(target) { true }
         end
       end
     end


### PR DESCRIPTION
Use more recent version or rubyzip. This will fix issues with old rubyzip on Fedora as well as it should resolve #1474