### PR TITLE
Show backups that will be migrated from PGBackups

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -144,8 +144,13 @@ class Heroku::Command::Pg < Heroku::Command::Base
     display_backups = transfers.select do |b|
       b[:from_type] == 'pg_dump' && b[:to_type] == 'gof3r'
     end.sort_by { |b| b[:created_at] }.reverse.map do |b|
+      old_pgb_name = b.has_key?(:options) && b[:options]["pgbackups_name"]
+      id = transfer_name(b[:num])
+      if old_pgb_name
+        id += " (was #{old_pgb_name})"
+      end
       {
-        "id" => transfer_name(b[:num]),
+        "id" => id,
         "created_at" => b[:created_at],
         "status" => transfer_status(b),
         "size" => size_pretty(b[:processed_bytes]),

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -160,8 +160,8 @@ module Heroku::Command
 
       before do
         (1..3).each do |n|
-          stub_pgapp.transfers_get(n, true)
-            .returns(transfers.find { |xfer| xfer[:num] == n })
+          stub_pgapp.transfers_get(n, true).
+            returns(transfers.find { |xfer| xfer[:num] == n })
         end
         stub_pgapp.transfers.returns(transfers)
       end


### PR DESCRIPTION
This cleans things up a bit and adds support for displaying backups from the old PGBackups system after we migrate them.

/cc @neovintage (N.B.: the backup naming scheme here is one suggested by pvh: just prefix anything coming from PGBackups with `o`--I can easily change this to something else that follows the same general mechanism)