### PR TITLE
Add `-s` to `pg:backups public-url` so people feel better about scripting

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -39,6 +39,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   #  capture DATABASE               # capture a new backup
   #  restore [[BACKUP_ID] DATABASE] # restore a backup (default latest) to a database (default DATABASE_URL)
   #  public-url BACKUP_ID           # get secret but publicly accessible URL for BACKUP_ID to download it
+  #    -s, --suppress               #   Suppress expiration message (for use in scripts)
   #  cancel                         # cancel an in-progress backup
   #  delete BACKUP_ID               # delete an existing backup
   #  schedule DATABASE              # schedule nightly backups for given database
@@ -431,7 +432,7 @@ EOF
     end
 
     url_info = client.transfers_public_url(backup_num)
-    if $stdout.tty?
+    if $stdout.tty? && !options[:suppress]
       display <<-EOF
 The following URL will expire at #{url_info[:expires_at]}:
   "#{url_info[:url]}"

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -39,7 +39,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   #  capture DATABASE               # capture a new backup
   #  restore [[BACKUP_ID] DATABASE] # restore a backup (default latest) to a database (default DATABASE_URL)
   #  public-url BACKUP_ID           # get secret but publicly accessible URL for BACKUP_ID to download it
-  #    -s, --suppress               #   Suppress expiration message (for use in scripts)
+  #    -q, --quiet                  #   Hide expiration message (for use in scripts)
   #  cancel                         # cancel an in-progress backup
   #  delete BACKUP_ID               # delete an existing backup
   #  schedule DATABASE              # schedule nightly backups for given database
@@ -432,7 +432,7 @@ EOF
     end
 
     url_info = client.transfers_public_url(backup_num)
-    if $stdout.tty? && !options[:suppress]
+    if $stdout.tty? && !options[:quiet]
       display <<-EOF
 The following URL will expire at #{url_info[:expires_at]}:
   "#{url_info[:url]}"

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -270,6 +270,11 @@ Backup Size:      #{backup_size}.0B (50% compression)
         expect(stdout.chomp).to eq url1_info[:url]
       end
 
+      it "only prints the url if called with -s" do
+        stderr, stdout = execute("pg:backups public-url b001 -s")
+        expect(stdout.chomp).to eq url1_info[:url]
+      end
+
       it "defaults to the latest backup if none is specified" do
         stderr, stdout = execute("pg:backups public-url")
         expect(stdout).to include url2_info[:url]

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -270,8 +270,8 @@ Backup Size:      #{backup_size}.0B (50% compression)
         expect(stdout.chomp).to eq url1_info[:url]
       end
 
-      it "only prints the url if called with -s" do
-        stderr, stdout = execute("pg:backups public-url b001 -s")
+      it "only prints the url if called with -q" do
+        stderr, stdout = execute("pg:backups public-url b001 -q")
         expect(stdout.chomp).to eq url1_info[:url]
       end
 


### PR DESCRIPTION
This adds an option to force hiding the "This link will expire in..." text from `pg:backups public-url`. This isn't entirely necessary, as we already check for TTY, but [ruby can be tricky with that sometimes anyway](https://gist.github.com/timuruski/6072363). I'll be able to shut up more than a few support tickets with this.