### PR TITLE
Add FreeBSD as supported OS

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -131,6 +131,8 @@ class Heroku::JSPlugin
       "windows"
     when /openbsd/
       "openbsd"
+    when /freebsd/
+      "freebsd"
     else
       raise "unsupported on #{RbConfig::CONFIG['host_os']}"
     end


### PR DESCRIPTION
This is very similar to #1415. I got this error on my FreeBSD machine when trying to run `heroku login`:

```
beast% heroku login
 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

    Error:       unsupported on freebsd10.1 (RuntimeError)
    Command:     heroku login
    Version:     heroku-gem/3.31.2 (x86_64-freebsd10.1) ruby/2.1.3
    Error ID:    5eab83aec6844b4a97597d7b672bfa36


    More information in /home/freebsd/.heroku/error.log

beast% cat ~/.heroku/error.log 
Heroku client internal error.
unsupported on freebsd10
/usr/local/heroku/lib/heroku/jsplugin.rb:135:in `os'
/usr/local/heroku/lib/heroku/jsplugin.rb:87:in `bin'
/usr/local/heroku/lib/heroku/jsplugin.rb:5:in `setup?'
/usr/local/heroku/lib/heroku/jsplugin.rb:9:in `load!'
/usr/local/heroku/lib/heroku/command.rb:18:in `load'
/usr/local/heroku/lib/heroku/cli.rb:44:in `start'
/usr/local/heroku/bin/heroku:24:in `<main>'
Heroku client internal error.
unsupported on freebsd10.1
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:135:in `os'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:87:in `bin'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:5:in `setup?'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:9:in `load!'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/command.rb:18:in `load'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/cli.rb:44:in `start'
/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/bin/heroku:17:in `<top (required)>'
/home/freebsd/.gem/ruby/2.1.3/bin/heroku:23:in `load'
/home/freebsd/.gem/ruby/2.1.3/bin/heroku:23:in `<main>'
Heroku client internal error.
unsupported on freebsd10.1
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:135:in `os'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:87:in `bin'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:5:in `setup?'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/jsplugin.rb:9:in `load!'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/command.rb:18:in `load'
/usr/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/lib/heroku/cli.rb:44:in `start'
/home/freebsd/.gem/ruby/2.1.3/gems/heroku-3.31.2/bin/heroku:17:in `<top (required)>'
/home/freebsd/.gem/ruby/2.1.3/bin/heroku:23:in `load'
/home/freebsd/.gem/ruby/2.1.3/bin/heroku:23:in `<main>'
```

Looking at the manifest linked further down in this file, I saw FreeBSD was in there, and adding these two lines seems to make the Heroku client work.