### PR TITLE
Add buildpacks command

### DIFF
--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -45,23 +45,21 @@ module Heroku::Command
       end
 
       validate_arguments!
-      index = options[:index] || 1
+      index = (options[:index] || 1).to_i
       index -= 1
 
       app_buildpacks = api.get_app_buildpacks_v3(app)[:body]
 
-      buildpack_urls = []
-
-      # overwrite the buildpack at index
-      if app_buildpacks.size >= index
-        app_buildpacks.each do |buildpack|
-          ordinal = buildpack["ordinal"]
-          if ordinal == index
-            buildpack_urls << buildpack_url
-          end
-          buildpack_urls << buildpack["buildpack"]["url"]
+      buildpack_urls = app_buildpacks.map do |buildpack|
+        ordinal = buildpack["ordinal"].to_i
+        if ordinal == index
+          buildpack_url
+        else
+          buildpack["buildpack"]["url"]
         end
-      else
+      end
+
+      if app_buildpacks.size <= index
         buildpack_urls << buildpack_url
       end
 

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -153,7 +153,6 @@ module Heroku::Command
       end
 
       update_buildpacks(buildpack_urls, "removed")
-
     end
 
     # buildpack:clear

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -92,7 +92,7 @@ module Heroku::Command
       end
 
       validate_arguments!
-      index = (options[:index] || 1).to_i
+      index = (options[:index] || -1).to_i
       index -= 1
 
       app_buildpacks = api.get_app_buildpacks_v3(app)[:body]

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -132,7 +132,7 @@ module Heroku::Command
     def remove
       if buildpack_url = shift_argument
         if options[:index]
-          error("Please choose either index or Buildpack URL, but not both, as arguments to this command!")
+          error("Please choose either index or Buildpack URL, but not both, as arguments to this command.")
         end
       else
         validate_arguments!

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -175,7 +175,7 @@ module Heroku::Command
         display_buildpacks(buildpack_urls)
         display "Run `git push heroku master` to create a new release using these buildpacks."
       elsif buildpack_urls.size == 1
-        display "Buildpack removed. Next release on #{app} will use #{buildpack_url}."
+        display "Buildpack removed. Next release on #{app} will use #{buildpack_urls.first}."
         display "Run `git push heroku master` to create a new release using this buildpack."
       else
         vars = api.get_config_vars(app).body

--- a/lib/heroku/command/buildpack.rb
+++ b/lib/heroku/command/buildpack.rb
@@ -52,10 +52,13 @@ module Heroku::Command
 
       buildpack_urls = app_buildpacks.map do |buildpack|
         ordinal = buildpack["ordinal"].to_i
-        if ordinal == index
+        existing_url = buildpack["buildpack"]["url"]
+        if existing_url == buildpack_url
+          error("The buildpack #{buildpack_url} is already set on your app.")
+        elsif ordinal == index
           buildpack_url
         else
-          buildpack["buildpack"]["url"]
+          existing_url
         end
       end
 
@@ -91,10 +94,13 @@ module Heroku::Command
 
       buildpack_urls = app_buildpacks.map { |buildpack|
         ordinal = buildpack["ordinal"].to_i
-        if ordinal == index
-          [buildpack_url, buildpack["buildpack"]["url"]]
+        existing_url = buildpack["buildpack"]["url"]
+        if existing_url == buildpack_url
+          error("The buildpack #{buildpack_url} is already set on your app.")
+        elsif ordinal == index
+          [buildpack_url, existing_url]
         else
-          buildpack["buildpack"]["url"]
+          existing_url
         end
       }.flatten
 

--- a/lib/heroku/command/buildpacks.rb
+++ b/lib/heroku/command/buildpacks.rb
@@ -44,7 +44,7 @@ module Heroku::Command
         error("Usage: heroku buildpacks:set BUILDPACK_URL.\nMust specify target buildpack URL.")
       end
 
-      index = get_index(1)
+      index = get_index(0)
 
       mutate_buildpacks_constructive(buildpack_url, index, "set") do |app_buildpacks|
         app_buildpacks.map do |buildpack|

--- a/lib/heroku/command/buildpacks.rb
+++ b/lib/heroku/command/buildpacks.rb
@@ -92,10 +92,11 @@ module Heroku::Command
         if options[:index]
           error("Please choose either index or Buildpack URL, but not both.")
         end
+      elsif index = get_index
+        # cool!
       else
-        index = get_index
+        error("Usage: heroku buildpacks:remove [BUILDPACK_URL].\nMust specify a buildpack to remove, either by index or URL.")
       end
-
 
       mutate_buildpacks(buildpack_url, index, "removed") do |app_buildpacks|
         if app_buildpacks.size == 0

--- a/lib/heroku/command/buildpacks.rb
+++ b/lib/heroku/command/buildpacks.rb
@@ -25,7 +25,7 @@ module Heroku::Command
         display("#{app} has no Buildpack URL set.")
       else
         styled_header("#{app} Buildpack URL#{app_buildpacks.size > 1 ? 's' : ''}")
-        display_buildpacks(app_buildpacks.map{|bp| bp["buildpack"]["url"]})
+        display_buildpacks(app_buildpacks.map{|bp| bp["buildpack"]["url"]}, "")
       end
     end
 
@@ -193,12 +193,12 @@ module Heroku::Command
       display_buildpack_change(buildpack_urls, action)
     end
 
-    def display_buildpacks(buildpacks)
+    def display_buildpacks(buildpacks, indent="  ")
       if (buildpacks.size == 1)
         display(buildpacks.first)
       else
         buildpacks.each_with_index do |bp, i|
-          display("  #{i+1}. #{bp}")
+          display("#{indent}#{i+1}. #{bp}")
         end
       end
     end

--- a/lib/heroku/command/buildpacks.rb
+++ b/lib/heroku/command/buildpacks.rb
@@ -5,15 +5,15 @@ module Heroku::Command
 
   # manage the buildpack for an app
   #
-  class Buildpack < Base
+  class Buildpacks < Base
 
-    # buildpack
+    # buildpacks
     #
-    # display the buildpack_url for an app
+    # display the buildpack_url(s) for an app
     #
     #Examples:
     #
-    # $ heroku buildpack
+    # $ heroku buildpacks
     # https://github.com/heroku/heroku-buildpack-ruby
     #
     def index
@@ -29,7 +29,7 @@ module Heroku::Command
       end
     end
 
-    # buildpack:set BUILDPACK_URL
+    # buildpacks:set BUILDPACK_URL
     #
     # set new app buildpack, overwriting into list of buildpacks if neccessary
     #
@@ -37,11 +37,11 @@ module Heroku::Command
     #
     #Example:
     #
-    # $ heroku buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby
+    # $ heroku buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-ruby
     #
     def set
       unless buildpack_url = shift_argument
-        error("Usage: heroku buildpack:set BUILDPACK_URL.\nMust specify target buildpack URL.")
+        error("Usage: heroku buildpacks:set BUILDPACK_URL.\nMust specify target buildpack URL.")
       end
 
       validate_arguments!
@@ -71,7 +71,7 @@ module Heroku::Command
       update_buildpacks(buildpack_urls, "set")
     end
 
-    # buildpack:add BUILDPACK_URL
+    # buildpacks:add BUILDPACK_URL
     #
     # add new app buildpack, inserting into list of buildpacks if neccessary
     #
@@ -79,11 +79,11 @@ module Heroku::Command
     #
     #Example:
     #
-    # $ heroku buildpack:add -i 1 https://github.com/heroku/heroku-buildpack-ruby
+    # $ heroku buildpacks:add -i 1 https://github.com/heroku/heroku-buildpack-ruby
     #
     def add
       unless buildpack_url = shift_argument
-        error("Usage: heroku buildpack:add BUILDPACK_URL.\nMust specify target buildpack URL.")
+        error("Usage: heroku buildpacks:add BUILDPACK_URL.\nMust specify target buildpack URL.")
       end
 
       validate_arguments!
@@ -113,7 +113,7 @@ module Heroku::Command
       update_buildpacks(buildpack_urls, "added")
     end
 
-    # buildpack:remove [BUILDPACK_URL]
+    # buildpacks:remove [BUILDPACK_URL]
     #
     # remove a buildpack set on the app
     #
@@ -161,7 +161,7 @@ module Heroku::Command
       update_buildpacks(buildpack_urls, "removed")
     end
 
-    # buildpack:clear
+    # buildpacks:clear
     #
     # clear all buildpacks set on the app
     #

--- a/lib/heroku/command/buildpacks.rb
+++ b/lib/heroku/command/buildpacks.rb
@@ -167,7 +167,7 @@ module Heroku::Command
     #
     def clear
       api.put_app_buildpacks_v3(app, {:updates => []})
-      display_no_buildpacks("(s) cleared")
+      display_no_buildpacks("s cleared")
     end
 
     private

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -303,7 +303,6 @@ Buildpack(s) cleared.
       context "with no buildpacks" do
         before(:each) do
           Excon.stubs.shift
-          Excon.stubs.shift
           stub_get
         end
 
@@ -325,42 +324,52 @@ Buildpack(s) cleared.
       end
 
       context "with one buildpack" do
-        before(:each) do
-          Excon.stubs.shift
-          Excon.stubs.shift
-          stub_get("https://github.com/heroku/heroku-buildpack-java")
-        end
+        context "reports and error" do
+          before(:each) do
+            Excon.stubs.shift
+            stub_get("https://github.com/heroku/heroku-buildpack-java")
+          end
 
-        it "reports an error index is out of range" do
-          stderr, stdout = execute("buildpack:remove -i 9")
-          expect(stdout).to eq("")
-          expect(stderr).to eq <<-STDOUT
+          it "invalid arguments" do
+            stderr, stdout = execute("buildpack:remove -i 1 https://github.com/heroku/heroku-buildpack-java")
+            expect(stdout).to eq("")
+            expect(stderr).to eq <<-STDOUT
+ !    Please choose either index or Buildpack URL, but not both, as arguments to this command.
+            STDOUT
+          end
+
+          it "index is out of range" do
+            stderr, stdout = execute("buildpack:remove -i 9")
+            expect(stdout).to eq("")
+            expect(stderr).to eq <<-STDOUT
  !    Invalid index. Only valid value is 1.
-          STDOUT
-        end
+            STDOUT
+          end
 
-        it "reports an error buildpack_url is not found" do
-          stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-foobar")
-          expect(stdout).to eq("")
-          expect(stderr).to eq <<-STDOUT
+          it "buildpack_url is not found" do
+            stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-foobar")
+            expect(stdout).to eq("")
+            expect(stderr).to eq <<-STDOUT
  !    Buildpack not found. Nothing was removed.
-          STDOUT
+            STDOUT
+          end
         end
       end
 
       context "with two buildpack" do
-        before(:each) do
-          Excon.stubs.shift
-          Excon.stubs.shift
-          stub_get("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
-        end
+        context "reports and error" do
+          before(:each) do
+            Excon.stubs.shift
+            stub_get("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
+          end
 
-        it "reports an error index is out of range" do
-          stderr, stdout = execute("buildpack:remove -i 9")
-          expect(stdout).to eq("")
-          expect(stderr).to eq <<-STDOUT
+          it "index is out of range" do
+            stderr, stdout = execute("buildpack:remove -i 9")
+            expect(stdout).to eq("")
+            expect(stderr).to eq <<-STDOUT
  !    Invalid index. Please choose a value between 1 and 2
-          STDOUT
+            STDOUT
+          end
         end
 
       end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -38,7 +38,7 @@ module Heroku::Command
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
 === example Buildpack URL
-https://github.com/heroku/heroku-buildpack-ruby
+  https://github.com/heroku/heroku-buildpack-ruby
         STDOUT
       end
 
@@ -153,7 +153,9 @@ Run `git push heroku master` to create a new release using https://github.com/he
             stderr, stdout = execute("buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
-Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
+Buildpack set. Next release on example will use:
+  1. https://github.com/heroku/heroku-buildpack-ruby
+  2. https://github.com/heroku/heroku-buildpack-nodejs
 Run `git push heroku master` to create a new release using https://github.com/heroku/heroku-buildpack-ruby.
             STDOUT
           end
@@ -167,7 +169,10 @@ Run `git push heroku master` to create a new release using https://github.com/he
             stderr, stdout = execute("buildpack:set -i 99 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
-Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
+Buildpack set. Next release on example will use:
+  1. https://github.com/heroku/heroku-buildpack-java
+  2. https://github.com/heroku/heroku-buildpack-nodejs
+  3. https://github.com/heroku/heroku-buildpack-ruby
 Run `git push heroku master` to create a new release using https://github.com/heroku/heroku-buildpack-ruby.
             STDOUT
           end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -73,34 +73,34 @@ Run `git push heroku master` to create a new release using https://github.com/he
       end
     end
 
-    describe "unset" do
-      it "unsets the buildpack URL" do
-        stderr, stdout = execute("buildpack:unset")
+    describe "clear" do
+      it "clears the buildpack URL" do
+        stderr, stdout = execute("buildpack:clear")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
-Buildpack unset. Next release on example will detect buildpack normally.
+Buildpack(s) cleared. Next release on example will detect buildpack normally.
         STDOUT
       end
 
-      it "unsets and warns about buildpack URL config var" do
+      it "clears and warns about buildpack URL config var" do
         execute("config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
-        stderr, stdout = execute("buildpack:unset")
+        stderr, stdout = execute("buildpack:clear")
         expect(stderr).to eq <<-STDERR
 WARNING: The BUILDPACK_URL config var is still set and will be used for the next release
         STDERR
         expect(stdout).to eq <<-STDOUT
-Buildpack unset.
+Buildpack(s) cleared.
         STDOUT
       end
 
-      it "unsets and warns about language pack URL config var" do
+      it "clears and warns about language pack URL config var" do
         execute("config:set LANGUAGE_PACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
-        stderr, stdout = execute("buildpack:unset")
+        stderr, stdout = execute("buildpack:clear")
         expect(stderr).to eq <<-STDERR
 WARNING: The LANGUAGE_PACK_URL config var is still set and will be used for the next release
         STDERR
         expect(stdout).to eq <<-STDOUT
-Buildpack unset.
+Buildpack(s) cleared.
         STDOUT
       end
     end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -298,5 +298,72 @@ Buildpack(s) cleared.
         STDOUT
       end
     end
+
+    describe "remove" do
+      context "with no buildpacks" do
+        before(:each) do
+          Excon.stubs.shift
+          Excon.stubs.shift
+          stub_get
+        end
+
+        it "reports an error removing index" do
+          stderr, stdout = execute("buildpack:remove -i 1")
+          expect(stdout).to eq("")
+          expect(stderr).to eq <<-STDOUT
+ !    No buildpacks were found. Next release on example will detect buildpack normally.
+          STDOUT
+        end
+
+        it "reports an error removing buildpack_url" do
+          stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-ruby")
+          expect(stdout).to eq("")
+          expect(stderr).to eq <<-STDOUT
+ !    No buildpacks were found. Next release on example will detect buildpack normally.
+          STDOUT
+        end
+      end
+
+      context "with one buildpack" do
+        before(:each) do
+          Excon.stubs.shift
+          Excon.stubs.shift
+          stub_get("https://github.com/heroku/heroku-buildpack-java")
+        end
+
+        it "reports an error index is out of range" do
+          stderr, stdout = execute("buildpack:remove -i 9")
+          expect(stdout).to eq("")
+          expect(stderr).to eq <<-STDOUT
+ !    Invalid index. Only valid value is 1.
+          STDOUT
+        end
+
+        it "reports an error buildpack_url is not found" do
+          stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-foobar")
+          expect(stdout).to eq("")
+          expect(stderr).to eq <<-STDOUT
+ !    Buildpack not found. Nothing was removed.
+          STDOUT
+        end
+      end
+
+      context "with two buildpack" do
+        before(:each) do
+          Excon.stubs.shift
+          Excon.stubs.shift
+          stub_get("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
+        end
+
+        it "reports an error index is out of range" do
+          stderr, stdout = execute("buildpack:remove -i 9")
+          expect(stdout).to eq("")
+          expect(stderr).to eq <<-STDOUT
+ !    Invalid index. Please choose a value between 1 and 2
+          STDOUT
+        end
+
+      end
+    end
   end
 end

--- a/spec/heroku/command/buildpack_spec.rb
+++ b/spec/heroku/command/buildpack_spec.rb
@@ -211,6 +211,59 @@ Buildpack added. Next release on example will use:
 Run `git push heroku master` to create a new release using these buildpacks.
           STDOUT
         end
+
+        it "adds a buildpack URL to the end of the list" do
+          stub_put("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-ruby")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+Buildpack added. Next release on example will use:
+  1. https://github.com/heroku/heroku-buildpack-java
+  2. https://github.com/heroku/heroku-buildpack-ruby
+Run `git push heroku master` to create a new release using these buildpacks.
+          STDOUT
+        end
+      end
+
+      context "with two existing buildpacks" do
+        before(:each) do
+          Excon.stubs.shift
+          Excon.stubs.shift
+          stub_get("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
+        end
+
+        it "inserts a buildpack URL at index" do
+          stub_put(
+            "https://github.com/heroku/heroku-buildpack-java",
+            "https://github.com/heroku/heroku-buildpack-ruby",
+            "https://github.com/heroku/heroku-buildpack-nodejs")
+          stderr, stdout = execute("buildpack:add -i 2 https://github.com/heroku/heroku-buildpack-ruby")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+Buildpack added. Next release on example will use:
+  1. https://github.com/heroku/heroku-buildpack-java
+  2. https://github.com/heroku/heroku-buildpack-ruby
+  3. https://github.com/heroku/heroku-buildpack-nodejs
+Run `git push heroku master` to create a new release using these buildpacks.
+          STDOUT
+        end
+
+        it "adds a buildpack URL to the end of the list" do
+          stub_put(
+            "https://github.com/heroku/heroku-buildpack-java",
+            "https://github.com/heroku/heroku-buildpack-nodejs",
+            "https://github.com/heroku/heroku-buildpack-ruby")
+          stub_put("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
+          stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-ruby")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+Buildpack added. Next release on example will use:
+  1. https://github.com/heroku/heroku-buildpack-java
+  2. https://github.com/heroku/heroku-buildpack-nodejs
+  3. https://github.com/heroku/heroku-buildpack-ruby
+Run `git push heroku master` to create a new release using these buildpacks.
+          STDOUT
+        end
       end
     end
 

--- a/spec/heroku/command/buildpacks_spec.rb
+++ b/spec/heroku/command/buildpacks_spec.rb
@@ -67,6 +67,23 @@ example has no Buildpack URL set.
           STDOUT
         end
       end
+
+      context "with two buildpack URLs set" do
+        before(:each) do
+          Excon.stubs.shift
+          stub_get("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-ruby")
+        end
+
+        it "does not display a buildpack URL" do
+          stderr, stdout = execute("buildpacks")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+=== example Buildpack URLs
+1. https://github.com/heroku/heroku-buildpack-java
+2. https://github.com/heroku/heroku-buildpack-ruby
+          STDOUT
+        end
+      end
     end
 
     describe "set" do

--- a/spec/heroku/command/buildpacks_spec.rb
+++ b/spec/heroku/command/buildpacks_spec.rb
@@ -505,6 +505,15 @@ Run `git push heroku master` to create a new release using this buildpack.
  !    Invalid index. Please choose a value between 1 and 2
             STDOUT
           end
+
+          it "checks if index or url is provided" do
+            stderr, stdout = execute("buildpacks:remove")
+            expect(stdout).to eq("")
+            expect(stderr).to eq <<-STDOUT
+ !    Usage: heroku buildpacks:remove [BUILDPACK_URL].
+ !    Must specify a buildpack to remove, either by index or URL.
+            STDOUT
+          end
         end
       end
 

--- a/spec/heroku/command/buildpacks_spec.rb
+++ b/spec/heroku/command/buildpacks_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
-require "heroku/command/buildpack"
+require "heroku/command/buildpacks"
 
 module Heroku::Command
-  describe Buildpack do
+  describe Buildpacks do
 
     def stub_put(*buildpacks)
       Excon.stub({
@@ -45,7 +45,7 @@ module Heroku::Command
 
     describe "index" do
       it "displays the buildpack URL" do
-        stderr, stdout = execute("buildpack")
+        stderr, stdout = execute("buildpacks")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
 === example Buildpack URL
@@ -60,7 +60,7 @@ https://github.com/heroku/heroku-buildpack-ruby
         end
 
         it "does not display a buildpack URL" do
-          stderr, stdout = execute("buildpack")
+          stderr, stdout = execute("buildpacks")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 example has no Buildpack URL set.
@@ -77,7 +77,7 @@ example has no Buildpack URL set.
         end
 
         it "sets the buildpack URL" do
-          stderr, stdout = execute("buildpack:set https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:set https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -86,16 +86,16 @@ Run `git push heroku master` to create a new release using this buildpack.
         end
 
         it "handles a missing buildpack URL arg" do
-          stderr, stdout = execute("buildpack:set")
+          stderr, stdout = execute("buildpacks:set")
           expect(stderr).to eq <<-STDERR
- !    Usage: heroku buildpack:set BUILDPACK_URL.
+ !    Usage: heroku buildpacks:set BUILDPACK_URL.
  !    Must specify target buildpack URL.
           STDERR
           expect(stdout).to eq("")
         end
 
         it "sets the buildpack URL with index" do
-          stderr, stdout = execute("buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -115,7 +115,7 @@ Run `git push heroku master` to create a new release using this buildpack.
           it "overwrites an existing buildpack URL at index" do
             stub_put(
               "https://github.com/heroku/heroku-buildpack-ruby")
-            stderr, stdout = execute("buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -131,7 +131,7 @@ Run `git push heroku master` to create a new release using this buildpack.
           end
 
           it "fails if buildpack is already set" do
-            stderr, stdout = execute("buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    The buildpack https://github.com/heroku/heroku-buildpack-ruby is already set on your app.
@@ -152,7 +152,7 @@ Run `git push heroku master` to create a new release using this buildpack.
             stub_put(
               "https://github.com/heroku/heroku-buildpack-ruby",
               "https://github.com/heroku/heroku-buildpack-nodejs")
-            stderr, stdout = execute("buildpack:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:set -i 1 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use:
@@ -167,7 +167,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
               "https://github.com/heroku/heroku-buildpack-java",
               "https://github.com/heroku/heroku-buildpack-nodejs",
               "https://github.com/heroku/heroku-buildpack-ruby")
-            stderr, stdout = execute("buildpack:set -i 99 https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:set -i 99 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack set. Next release on example will use:
@@ -186,7 +186,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
           end
 
           it "fails if buildpack is already set" do
-            stderr, stdout = execute("buildpack:set -i 2 https://github.com/heroku/heroku-buildpack-java")
+            stderr, stdout = execute("buildpacks:set -i 2 https://github.com/heroku/heroku-buildpack-java")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    The buildpack https://github.com/heroku/heroku-buildpack-java is already set on your app.
@@ -204,7 +204,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
         end
 
         it "adds the buildpack URL" do
-          stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:add https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -213,16 +213,16 @@ Run `git push heroku master` to create a new release using this buildpack.
         end
 
         it "handles a missing buildpack URL arg" do
-          stderr, stdout = execute("buildpack:add")
+          stderr, stdout = execute("buildpacks:add")
           expect(stderr).to eq <<-STDERR
- !    Usage: heroku buildpack:add BUILDPACK_URL.
+ !    Usage: heroku buildpacks:add BUILDPACK_URL.
  !    Must specify target buildpack URL.
           STDERR
           expect(stdout).to eq("")
         end
 
         it "adds the buildpack URL with index" do
-          stderr, stdout = execute("buildpack:add -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:add -i 1 https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -240,7 +240,7 @@ Run `git push heroku master` to create a new release using this buildpack.
 
         it "inserts a buildpack URL at index" do
           stub_put("https://github.com/heroku/heroku-buildpack-ruby", "https://github.com/heroku/heroku-buildpack-java")
-          stderr, stdout = execute("buildpack:add -i 1 https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:add -i 1 https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use:
@@ -252,7 +252,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
 
         it "adds a buildpack URL to the end of the list" do
           stub_put("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-ruby")
-          stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:add https://github.com/heroku/heroku-buildpack-ruby")
           expect(stderr).to eq("")
           expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use:
@@ -276,7 +276,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
               "https://github.com/heroku/heroku-buildpack-java",
               "https://github.com/heroku/heroku-buildpack-ruby",
               "https://github.com/heroku/heroku-buildpack-nodejs")
-            stderr, stdout = execute("buildpack:add -i 2 https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:add -i 2 https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use:
@@ -293,7 +293,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
               "https://github.com/heroku/heroku-buildpack-nodejs",
               "https://github.com/heroku/heroku-buildpack-ruby")
             stub_put("https://github.com/heroku/heroku-buildpack-java", "https://github.com/heroku/heroku-buildpack-nodejs")
-            stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:add https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack added. Next release on example will use:
@@ -312,7 +312,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
           end
 
           it "inserts a buildpack URL at index" do
-            stderr, stdout = execute("buildpack:add https://github.com/heroku/heroku-buildpack-java")
+            stderr, stdout = execute("buildpacks:add https://github.com/heroku/heroku-buildpack-java")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    The buildpack https://github.com/heroku/heroku-buildpack-java is already set on your app.
@@ -324,7 +324,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
 
     describe "clear" do
       it "clears the buildpack URL" do
-        stderr, stdout = execute("buildpack:clear")
+        stderr, stdout = execute("buildpacks:clear")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
 Buildpack(s) cleared. Next release on example will detect buildpack normally.
@@ -333,7 +333,7 @@ Buildpack(s) cleared. Next release on example will detect buildpack normally.
 
       it "clears and warns about buildpack URL config var" do
         execute("config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
-        stderr, stdout = execute("buildpack:clear")
+        stderr, stdout = execute("buildpacks:clear")
         expect(stderr).to eq <<-STDERR
 WARNING: The BUILDPACK_URL config var is still set and will be used for the next release
         STDERR
@@ -344,7 +344,7 @@ Buildpack(s) cleared.
 
       it "clears and warns about language pack URL config var" do
         execute("config:set LANGUAGE_PACK_URL=https://github.com/heroku/heroku-buildpack-ruby")
-        stderr, stdout = execute("buildpack:clear")
+        stderr, stdout = execute("buildpacks:clear")
         expect(stderr).to eq <<-STDERR
 WARNING: The LANGUAGE_PACK_URL config var is still set and will be used for the next release
         STDERR
@@ -362,7 +362,7 @@ Buildpack(s) cleared.
         end
 
         it "reports an error removing index" do
-          stderr, stdout = execute("buildpack:remove -i 1")
+          stderr, stdout = execute("buildpacks:remove -i 1")
           expect(stdout).to eq("")
           expect(stderr).to eq <<-STDOUT
  !    No buildpacks were found. Next release on example will detect buildpack normally.
@@ -370,7 +370,7 @@ Buildpack(s) cleared.
         end
 
         it "reports an error removing buildpack_url" do
-          stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-ruby")
+          stderr, stdout = execute("buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby")
           expect(stdout).to eq("")
           expect(stderr).to eq <<-STDOUT
  !    No buildpacks were found. Next release on example will detect buildpack normally.
@@ -388,7 +388,7 @@ Buildpack(s) cleared.
           end
 
           it "removes index" do
-            stderr, stdout = execute("buildpack:remove -i 1")
+            stderr, stdout = execute("buildpacks:remove -i 1")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will detect buildpack normally.
@@ -396,7 +396,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
           end
 
           it "removes url" do
-            stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will detect buildpack normally.
@@ -411,7 +411,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
           end
 
           it "validates arguments" do
-            stderr, stdout = execute("buildpack:remove -i 1 https://github.com/heroku/heroku-buildpack-java")
+            stderr, stdout = execute("buildpacks:remove -i 1 https://github.com/heroku/heroku-buildpack-java")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    Please choose either index or Buildpack URL, but not both, as arguments to this command.
@@ -419,7 +419,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
           end
 
           it "checks if index is in range" do
-            stderr, stdout = execute("buildpack:remove -i 9")
+            stderr, stdout = execute("buildpacks:remove -i 9")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    Invalid index. Only valid value is 1.
@@ -427,7 +427,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
           end
 
           it "checks if buildpack_url is found" do
-            stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-foobar")
+            stderr, stdout = execute("buildpacks:remove https://github.com/heroku/heroku-buildpack-foobar")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    Buildpack not found. Nothing was removed.
@@ -446,7 +446,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
 
           it "removes index" do
             stub_put("https://github.com/heroku/heroku-buildpack-java")
-            stderr, stdout = execute("buildpack:remove -i 2")
+            stderr, stdout = execute("buildpacks:remove -i 2")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will use https://github.com/heroku/heroku-buildpack-java.
@@ -456,7 +456,7 @@ Run `git push heroku master` to create a new release using this buildpack.
 
           it "removes index" do
             stub_put("https://github.com/heroku/heroku-buildpack-ruby")
-            stderr, stdout = execute("buildpack:remove -i 1")
+            stderr, stdout = execute("buildpacks:remove -i 1")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will use https://github.com/heroku/heroku-buildpack-ruby.
@@ -466,7 +466,7 @@ Run `git push heroku master` to create a new release using this buildpack.
 
           it "removes url" do
             stub_put("https://github.com/heroku/heroku-buildpack-java")
-            stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will use https://github.com/heroku/heroku-buildpack-java.
@@ -482,7 +482,7 @@ Run `git push heroku master` to create a new release using this buildpack.
           end
 
           it "checks if index is in range" do
-            stderr, stdout = execute("buildpack:remove -i 9")
+            stderr, stdout = execute("buildpacks:remove -i 9")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
  !    Invalid index. Please choose a value between 1 and 2
@@ -506,7 +506,7 @@ Run `git push heroku master` to create a new release using this buildpack.
             stub_put(
               "https://github.com/heroku/heroku-buildpack-java",
               "https://github.com/heroku/heroku-buildpack-ruby")
-            stderr, stdout = execute("buildpack:remove -i 2")
+            stderr, stdout = execute("buildpacks:remove -i 2")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will use:
@@ -520,7 +520,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
             stub_put(
               "https://github.com/heroku/heroku-buildpack-java",
               "https://github.com/heroku/heroku-buildpack-nodejs")
-            stderr, stdout = execute("buildpack:remove https://github.com/heroku/heroku-buildpack-ruby")
+            stderr, stdout = execute("buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
 Buildpack removed. Next release on example will use:

--- a/spec/heroku/command/buildpacks_spec.rb
+++ b/spec/heroku/command/buildpacks_spec.rb
@@ -327,7 +327,7 @@ Run `git push heroku master` to create a new release using these buildpacks.
         stderr, stdout = execute("buildpacks:clear")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
-Buildpack(s) cleared. Next release on example will detect buildpack normally.
+Buildpacks cleared. Next release on example will detect buildpack normally.
         STDOUT
       end
 
@@ -338,7 +338,7 @@ Buildpack(s) cleared. Next release on example will detect buildpack normally.
 WARNING: The BUILDPACK_URL config var is still set and will be used for the next release
         STDERR
         expect(stdout).to eq <<-STDOUT
-Buildpack(s) cleared.
+Buildpacks cleared.
         STDOUT
       end
 
@@ -349,7 +349,7 @@ Buildpack(s) cleared.
 WARNING: The LANGUAGE_PACK_URL config var is still set and will be used for the next release
         STDERR
         expect(stdout).to eq <<-STDOUT
-Buildpack(s) cleared.
+Buildpacks cleared.
         STDOUT
       end
     end

--- a/spec/heroku/command/buildpacks_spec.rb
+++ b/spec/heroku/command/buildpacks_spec.rb
@@ -414,7 +414,7 @@ Buildpack removed. Next release on example will detect buildpack normally.
             stderr, stdout = execute("buildpacks:remove -i 1 https://github.com/heroku/heroku-buildpack-java")
             expect(stdout).to eq("")
             expect(stderr).to eq <<-STDOUT
- !    Please choose either index or Buildpack URL, but not both, as arguments to this command.
+ !    Please choose either index or Buildpack URL, but not both.
             STDOUT
           end
 


### PR DESCRIPTION
The PR changes the existing `buildpack` command to `buildpacks` and adds the behavior shown below.

*Before merging this* we may want to change the language used in codon for it's multi-buildpack behavior. Currently, it uses words like "Framework" because it copied the output directly from [Multi-buildpack](https://github.com/heroku/heroku-buildpack-multi), but this does not meaning anything to Heroku (we do not use this work in the Dev Center or official docs). It also does not indent like normal buildpacks.

#### list multi buildpacks
```
$ heroku buildpacks
=== example Buildpack URLs
1. https://github.com/heroku/heroku-buildpack-java
2. https://github.com/heroku/heroku-buildpack-ruby
```

#### add buildpacks
```
$ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nodejs
Buildpack added. Next release on example will use:
  1. https://github.com/heroku/heroku-buildpack-java
  2. https://github.com/heroku/heroku-buildpack-ruby
  3. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### add buildpacks at index
```
$ heroku buildpacks:add -i 1 https://github.com/ryandotsmith/null-buildpack
Buildpack added. Next release on example will use:
  1. https://github.com/ryandotsmith/null-buildpack
  2. https://github.com/heroku/heroku-buildpack-java
  3. https://github.com/heroku/heroku-buildpack-ruby
  4. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### set buildpacks at index
```
$ heroku buildpacks:set -i 2 https://github.com/ddollar/heroku-buildpack-apt
Buildpack set. Next release on example will use:
  1. https://github.com/ryandotsmith/null-buildpack
  2. https://github.com/ddollar/heroku-buildpack-apt
  3. https://github.com/heroku/heroku-buildpack-ruby
  4. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### set buildpacks w/o index
*This one is weird and may require discussion*
```
$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-java
Buildpack set. Next release on example will use:
  1. https://github.com/heroku/heroku-buildpack-java
  2. https://github.com/ddollar/heroku-buildpack-apt
  3. https://github.com/heroku/heroku-buildpack-ruby
  4. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### remove buildpacks by index
```
$ heroku buildpacks:remove -i 1
Buildpack removed. Next release on example will use:
  1. https://github.com/ddollar/heroku-buildpack-apt
  2. https://github.com/heroku/heroku-buildpack-ruby
  3. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### remove buildpacks by URL
```
$ heroku buildpacks:remove https://github.com/heroku/heroku-buildpack-ruby
Buildpack removed. Next release on example will use:
  1. https://github.com/ddollar/heroku-buildpack-apt
  2. https://github.com/heroku/heroku-buildpack-nodejs
Run `git push heroku master` to create a new release using these buildpacks.
```

#### clear all buildpacks 
```
$ heroku buildpacks:clear
Buildpacks cleared. Next release on example will detect buildpack normally.
```