### PR TITLE
only escape shell words if it is a tty

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -42,7 +42,8 @@ class Heroku::Command::Config < Heroku::Command::Base
       vars.each {|key, value| vars[key] = value.to_s}
       if options[:shell]
         vars.keys.sort.each do |key|
-          display(%{#{key}=#{Shellwords.shellescape vars[key]}})
+          out = $stdout.tty? ? Shellwords.shellescape(vars[key]) : vars[key]
+          display(%{#{key}=#{out}})
         end
       else
         styled_header("#{app} Config Vars")

--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -115,8 +115,9 @@ class Heroku::Command::Config < Heroku::Command::Base
 
     vars = api.get_config_vars(app).body
     key, value = vars.detect {|k,v| k == key}
-    if options[:shell]
-      display("#{key}=#{value}")
+    if options[:shell] && value
+      out = $stdout.tty? ? Shellwords.shellescape(value) : value
+      display("#{key}=#{out}")
     else
       display(value.to_s)
     end


### PR DESCRIPTION
```
bash-3.2$ heroku config -a forker -s
FOO=\+PLUS
```

```
bash-3.2$ heroku config -a forker -s >> .env
bash-3.2$ cat .env
FOO=+PLUS
```