### PR TITLE
Fix addons:open for paranoid apps

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -371,6 +371,7 @@ module Heroku::Command
         error("Usage: heroku addons:open ADDON\nMust specify ADDON to open.")
       end
       validate_arguments!
+      requires_preauth
 
       addon = resolve_addon!(addon_name)
       return addon if addon.is_a?(String)


### PR DESCRIPTION
Carried over from https://github.com/heroku/heroku-addon-attachments/commit/1cb5b30d7e62c89b4ae74ac0c2b18f8daa86d816 where this was only resolved on the old plugin