### PR TITLE
Fix unscheduling backups for some config var configurations

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -525,7 +525,7 @@ EOF
     end
 
     if schedule.nil?
-      display "No automatic daily backups for #{db || attachment.name} found"
+      display "No automatic daily backups for #{attachment.name} found"
     else
       hpg_client(attachment).unschedule(schedule[:uuid])
       display "Stopped automatic daily backups for #{attachment.name}"

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -513,16 +513,19 @@ EOF
     db = shift_argument
     validate_arguments!
 
+    if db.nil?
+      abort("Must specify database to unschedule backups for")
+    end
+
     attachment = generate_resolver.resolve(db, "DATABASE_URL")
 
     schedule = hpg_client(attachment).schedules.find do |s|
-      # attachment.name is HEROKU_POSTGRESQL_COLOR
       # s[:name] is HEROKU_POSTGRESQL_COLOR_URL
-      s[:name] =~ /#{attachment.name}/ || attachment.name =~ /#{s[:name]}/
+      s[:name] =~ /#{db}/i
     end
 
     if schedule.nil?
-      display "No automatic daily backups for #{attachment.name} found"
+      display "No automatic daily backups for #{db || attachment.name} found"
     else
       hpg_client(attachment).unschedule(schedule[:uuid])
       display "Stopped automatic daily backups for #{attachment.name}"

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -44,7 +44,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   #  delete BACKUP_ID               # delete an existing backup
   #  schedule DATABASE              # schedule nightly backups for given database
   #    --at '<hour>:00 <timezone>'  #   at a specific (24h clock) hour in the given timezone
-  #  unschedule SCHEDULE            # stop nightly backup for database
+  #  unschedule SCHEDULE            # stop nightly backups on this schedule
   #  schedules                      # list backup schedule
   def backups
     if args.count == 0
@@ -522,7 +522,7 @@ EOF
         schedule_names = schedules.map { |s| s[:name] }.join(", ")
         abort("Must specify schedule to cancel: existing schedules are #{schedule_names}")
       rescue StandardError
-        abort("Must specify schedule to cancel")
+        abort("Must specify schedule to cancel. Run `heroku help pg:backups` for usage information.")
       end
     end
 

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -145,7 +145,7 @@ module Heroku::Command
 
       it "complains when called without an argument" do
         stderr, stdout = execute("pg:backups unschedule --confirm example")
-        expect(stderr).to match(/Must specify database to unschedule/)
+        expect(stderr).to match(/Must specify schedule to cancel/)
         expect(stdout).to be_empty
       end
 

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -122,6 +122,40 @@ module Heroku::Command
       end
     end
 
+    describe "heroku pg:backups unschedule" do
+      let(:schedules) do
+        [ { name: 'HEROKU_POSTGRESQL_GREEN_URL',
+            uuid: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
+          { name: 'DATABASE_URL',
+            uuid: 'ffffffff-ffff-ffff-ffff-fffffffffffe' } ]
+      end
+
+      before do
+        stub_pg.schedules.returns(schedules)
+        allow_any_instance_of(Heroku::Helpers::HerokuPostgresql::Resolver)
+          .to receive(:app_attachments).and_return(example_attachments)
+      end
+
+      it "unschedules the specified backup" do
+        stub_pg.unschedule
+        stderr, stdout = execute("pg:backups unschedule green --confirm example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/Stopped automatic daily backups for/)
+      end
+
+      it "complains when called without an argument" do
+        stderr, stdout = execute("pg:backups unschedule --confirm example")
+        expect(stderr).to match(/Must specify database to unschedule/)
+        expect(stdout).to be_empty
+      end
+
+      it "indicates when no matching backup can be unscheduled" do
+        stderr, stdout = execute("pg:backups unschedule red --confirm example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/No automatic daily backups for/)
+      end
+    end
+
     describe "heroku pg:backups" do
       let(:logged_at)  { Time.now }
       let(:started_at)  { Time.now }


### PR DESCRIPTION
For some applications with aliased config vars, it's possible
that the unschedule command can be too stringent in verifying
the database to unschedule, making it impossible to unschedule
backups without manually calling the API.

This makes the unschedule verification much simpler.

/cc @chadbailey59 @neovintage @hgmnz 