### PR TITLE
v4 takeover

### DIFF
--- a/lib/heroku.rb
+++ b/lib/heroku.rb
@@ -1,4 +1,3 @@
-require "heroku/client"
 require "heroku/updater"
 require "heroku/version"
 

--- a/lib/heroku/cli.rb
+++ b/lib/heroku/cli.rb
@@ -9,16 +9,7 @@ load('heroku/updater.rb') # reload updater after possible inject_loadpath
 require 'heroku'
 require 'heroku/jsplugin'
 require 'heroku/rollbar'
-require 'multi_json'
-
-begin
-  # attempt to load the JSON parser bundled with ruby for multi_json
-  # we're doing this because several users apparently have gems broken
-  # due to OS upgrades. see: https://github.com/heroku/heroku/issues/932
-  require 'json'
-rescue LoadError
-  # let multi_json fallback to yajl/oj/okjson
-end
+require 'json'
 
 class Heroku::CLI
 

--- a/lib/heroku/cli.rb
+++ b/lib/heroku/cli.rb
@@ -6,22 +6,10 @@ end
 load('heroku/helpers.rb') # reload helpers after possible inject_loadpath
 load('heroku/updater.rb') # reload updater after possible inject_loadpath
 
-# exists and updated in the last 5 minutes
-if File.exist?(Heroku::Updater.updating_lock_path) &&
-    File.mtime(Heroku::Updater.updating_lock_path) > (Time.now - 5*60)
-  $stderr.puts "Heroku Toolbelt is currently updating. Please wait a few seconds and try your command again."
-  exit 1
-end
-
 require 'heroku'
-require 'heroku/command'
-require 'heroku/git'
-require 'heroku/helpers'
-require 'heroku/http_instrumentor'
+require 'heroku/jsplugin'
 require 'heroku/rollbar'
-require 'rest_client'
 require 'multi_json'
-require 'heroku-api'
 
 begin
   # attempt to load the JSON parser bundled with ruby for multi_json
@@ -39,8 +27,10 @@ class Heroku::CLI
   def self.start(*args)
     $stdin.sync = true if $stdin.isatty
     $stdout.sync = true if $stdout.isatty
-    Heroku::Git.check_git_version
     command = args.shift.strip rescue "help"
+    Heroku::JSPlugin.try_takeover(command, args) if Heroku::JSPlugin.setup?
+    require 'heroku/command'
+    Heroku::Git.check_git_version
     Heroku::Command.load
     Heroku::Command.run(command, args)
     Heroku::Updater.autoupdate

--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -5,7 +5,6 @@ require 'heroku/command'
 require 'heroku/helpers'
 require 'heroku/version'
 require 'heroku/client/ssl_endpoint'
-require 'rest_client'
 
 # A Ruby class to call the Heroku REST API.  You might use this if you want to
 # manage your Heroku apps from within a Ruby program, such as Capistrano.

--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -1,8 +1,11 @@
 require 'heroku/helpers'
 require 'heroku/plugin'
-require 'heroku/jsplugin'
 require 'heroku/version'
-require "optparse"
+require 'heroku/http_instrumentor'
+require 'heroku/git'
+require 'heroku-api'
+require 'optparse'
+require 'rest_client'
 
 module Heroku
   module Command

--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -6,6 +6,7 @@ require 'heroku/git'
 require 'heroku-api'
 require 'optparse'
 require 'rest_client'
+require 'multi_json'
 
 module Heroku
   module Command

--- a/lib/heroku/command/help.rb
+++ b/lib/heroku/command/help.rb
@@ -96,6 +96,7 @@ private
   def skip_command?(command)
     return true if command[:help] =~ /DEPRECATED:/
     return true if command[:help] =~ /^ HIDDEN:/
+    return true if command[:hidden]
     false
   end
 

--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -212,14 +212,12 @@ module Heroku
     end
 
     def json_encode(object)
-      MultiJson.dump(object)
-    rescue MultiJson::ParseError
-      nil
+      JSON.generate(object)
     end
 
     def json_decode(json)
-      MultiJson.load(json)
-    rescue MultiJson::ParseError
+      JSON.parse(json)
+    rescue JSON::ParserError
       nil
     end
 

--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -5,6 +5,17 @@ class Heroku::JSPlugin
     @is_setup ||= File.exists? bin
   end
 
+  def self.try_takeover(command, args)
+    command = command.split(':')
+    if command.length == 1
+      command = commands.find { |t| t["topic"] == command[0] && t["command"] == nil }
+    else
+      command = commands.find { |t| t["topic"] == command[0] && t["command"] == command[1] }
+    end
+    return if !command || command["hidden"]
+    run(command['topic'], command['command'], ARGV[1..-1])
+  end
+
   def self.load!
     return unless setup?
     this = self

--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -123,6 +123,7 @@ class Heroku::JSPlugin
 
   def self.run(topic, command, args)
     cmd = command ? "#{topic}:#{command}" : topic
+    debug("running #{cmd} on v4")
     exec self.bin, cmd, *args
   end
 

--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -43,7 +43,8 @@ class Heroku::JSPlugin
         :method    => :run,
         :banner    => plugin['usage'],
         :summary   => " #{plugin['description']}",
-        :help      => help
+        :help      => help,
+        :hidden    => plugin['hidden'],
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ Coveralls.wear!
 require "excon"
 
 require "heroku/cli"
+require "heroku/client"
 require "rspec"
 require "rr"
 require "fakefs/safe"


### PR DESCRIPTION
This allows the v4 CLI to have the first chance at running a command before v3.
I also optimized the load order by only loading the necessary ruby files before this happens.