### PR TITLE
autofix v4 installs

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -72,6 +72,8 @@ class Heroku::JSPlugin
     commands_info['commands']
   rescue
     $stderr.puts "error loading plugin commands"
+    # Remove v4 if it is causing issues (for now)
+    File.delete(bin)
     return []
   end
 


### PR DESCRIPTION
some users have unfortunately downloaded v4 clients that are not
autoupdating. This will simply remove v4 if it is causing an issue.

It will automatically be redownloaded if it is needed.