### PR TITLE
pg:promote: work with config var names again and create JIT backup attachments for outgoing database

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -85,6 +85,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     end
     validate_arguments!
 
+    db = db.sub(/_URL$/, '') # allow promoting with a var name
     addon = resolve_addon!(db)
 
     attachment_name = 'DATABASE'

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -86,7 +86,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     validate_arguments!
 
     db = db.sub(/_URL$/, '') # allow promoting with a var name
-    addon = resolve_addon!(db)
+    addon = resolve_addon!(db) { |addon| addon['addon_service']['name'] == 'heroku-postgresql' }
 
     promoted_name = 'DATABASE'
 

--- a/lib/heroku/helpers/addons/resolve.rb
+++ b/lib/heroku/helpers/addons/resolve.rb
@@ -16,8 +16,8 @@ module Heroku::Helpers
       # Finds attachments that match provided identifier.
       #
       # Always returns an Array of 0 or more results.
-      def resolve_attachment(identifier)
-        case identifier
+      def resolve_attachment(identifier, &filter)
+        results = case identifier
         when UUID
           [get_attachment(identifier)].compact
         when ATTACHMENT
@@ -35,13 +35,15 @@ module Heroku::Helpers
         else
           []
         end
+
+        filter ? results.select(&filter) : results
       end
 
       # Finds a single attachment unambiguously given an identifier.
       #
       # Returns an attachment hash or exits with an error.
-      def resolve_attachment!(identifier)
-        results = resolve_attachment(identifier)
+      def resolve_attachment!(identifier, &filter)
+        results = resolve_attachment(identifier, &filter)
 
         case results.count
         when 1
@@ -68,8 +70,8 @@ module Heroku::Helpers
       # Returns an array in every case except for when using a service name for an
       # non-existent add-on. In that case, the error message is returned.
       #
-      def resolve_addon(identifier)
-        case identifier
+      def resolve_addon(identifier, &filter)
+        results = case identifier
         when UUID
           return [get_addon(identifier)].compact
         when ATTACHMENT
@@ -110,13 +112,15 @@ module Heroku::Helpers
 
           []
         end
+
+        filter ? results.select(&filter) : results
       end
 
       # Finds a single add-on unambiguously given an identifier.
       #
       # Returns an add-on hash or exits with an error.
-      def resolve_addon!(identifier)
-        results = resolve_addon(identifier)
+      def resolve_addon!(identifier, &filter)
+        results = resolve_addon(identifier, &filter)
 
         case results.count
         when 1

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -157,7 +157,7 @@ STDOUT
       before do
         resource = build_addon(
           name: "walking-slowly-42",
-          addon_service: { name: "heroku-posgresql:ronin" },
+          addon_service: { name: "heroku-postgresql" },
           plan:          { name: "ronin" },
           app:           { id: 1, name: "example" })
 
@@ -195,7 +195,7 @@ STDOUT
       it "promotes the specified database resource name" do
         stderr, stdout = execute("pg:promote walking-slowly-42 --confirm example")
         expect(stderr).to eq("")
-        expect(stdout).to eq <<-STDOUT
+        expect(stdout).to include <<-STDOUT
 Promoting walking-slowly-42 to DATABASE_URL on example... done
 STDOUT
         expect(api.get_config_vars("example").body["DATABASE_URL"]).to eq("postgres://database_url")
@@ -204,7 +204,7 @@ STDOUT
       it "promotes the specified database by config var" do
         stderr, stdout = execute("pg:promote HEROKU_POSTGRESQL_RONIN_URL --confirm example")
         expect(stderr).to eq("")
-        expect(stdout).to eq <<-STDOUT
+        expect(stdout).to include <<-STDOUT
 Promoting walking-slowly-42 to DATABASE_URL on example... done
 STDOUT
         expect(api.get_config_vars("example").body["DATABASE_URL"]).to eq("postgres://database_url")
@@ -213,7 +213,7 @@ STDOUT
       it "promotes the specified database by attachment substring" do
         stderr, stdout = execute("pg:promote RONIN --confirm example")
         expect(stderr).to eq("")
-        expect(stdout).to eq <<-STDOUT
+        expect(stdout).to include <<-STDOUT
 Promoting walking-slowly-42 to DATABASE_URL on example... done
 STDOUT
         expect(api.get_config_vars("example").body["DATABASE_URL"]).to eq("postgres://database_url")

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -154,7 +154,7 @@ STDOUT
     context "promotion" do
       include Support::Addons
 
-      it "promotes the specified database" do
+      before do
         resource = build_addon(
           name: "walking-slowly-42",
           addon_service: { name: "heroku-posgresql:ronin" },
@@ -162,7 +162,7 @@ STDOUT
           app:           { id: 1, name: "example" })
 
         ronin = build_attachment(
-          name:  "HEROKU_POSTGRESQL_RONIN_URL",
+          name:  "HEROKU_POSTGRESQL_RONIN",
           app:   { id: 1, name: "example" },
           addon: { id: resource[:id], name: "dreaming-ably-42" })
 
@@ -170,15 +170,47 @@ STDOUT
           { body: MultiJson.encode(resource), status: 200 }
         end
 
-        Excon.stub(method: :get, path: "/apps/example/addon-attachments/RONIN") do
+        Excon.stub(method: :get, path: "/addons/#{resource[:name]}") do
+          { body: MultiJson.encode(resource), status: 200 }
+        end
+
+        Excon.stub(method: :get, path: "/apps/example/addon-attachments/HEROKU_POSTGRESQL_RONIN") do
           { body: MultiJson.encode(ronin), status: 200 }
+        end
+
+        Excon.stub(method: :get, path: "/apps/example/addon-attachments/RONIN") do
+          { body: MultiJson.encode({}), status: 404 }
+        end
+
+        Excon.stub(method: :get, path: "/apps/example/addon-attachments") do
+          { body: MultiJson.encode([ronin]), status: 200 }
         end
 
         Excon.stub(method: :post, path: "/addon-attachments") do
           database = ronin.merge(name: "DATABASE")
           { body: MultiJson.encode(database), status: 201 }
         end
+      end
 
+      it "promotes the specified database resource name" do
+        stderr, stdout = execute("pg:promote walking-slowly-42 --confirm example")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+Promoting walking-slowly-42 to DATABASE_URL on example... done
+STDOUT
+        expect(api.get_config_vars("example").body["DATABASE_URL"]).to eq("postgres://database_url")
+      end
+
+      it "promotes the specified database by config var" do
+        stderr, stdout = execute("pg:promote HEROKU_POSTGRESQL_RONIN_URL --confirm example")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+Promoting walking-slowly-42 to DATABASE_URL on example... done
+STDOUT
+        expect(api.get_config_vars("example").body["DATABASE_URL"]).to eq("postgres://database_url")
+      end
+
+      it "promotes the specified database by attachment substring" do
         stderr, stdout = execute("pg:promote RONIN --confirm example")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT


### PR DESCRIPTION
This PR has 2 distinct changes:

* Fix regression preventing promotion with full config var name (e.g. `heroku pg:promote HEROKU_POSTGRESQL_CYAN_URL`)
* Avoid "can't remove last attachment" error message when promoting by ensuring there is at least 1 alternate attachment for the add-on which currently occupies the `DATABASE` alias.

E.g., given: 

```sh-session
$ heroku addons:create heroku-postgresql -a mighty-mesa-1351
Creating helping-busily-4207... done
Adding helping-busily-4207 to mighty-mesa-1351... done
Setting DATABASE_URL and restarting mighty-mesa-1351... done, v3
Database has been created and is available
 ! This database is empty. If upgrading, you can transfer
 ! data from another database with pgbackups:restore
Use `heroku addons:docs heroku-postgresql` to view documentation.

$ heroku addons:create heroku-postgresql -a mighty-mesa-1351
Creating cooling-keenly-1251... done
Adding cooling-keenly-1251 to mighty-mesa-1351... done
Setting HEROKU_POSTGRESQL_BRONZE_URL and restarting mighty-mesa-1351... done, v4
Database has been created and is available
 ! This database is empty. If upgrading, you can transfer
 ! data from another database with pgbackups:restore
Use `heroku addons:docs heroku-postgresql` to view documentation.
```

Before second change:

```sh-session
$ heroku pg:promote BRONZE -a mighty-mesa-1351
Promoting cooling-keenly-1251 to DATABASE_URL on mighty-mesa-1351... failed
 !    DATABASE on mighty-mesa-1351 is the last billing attachment to helping-busily-4207; either remove the add-on entirely or add a new attachment to it before replacing its config vars.
```

After second change:

```sh-session
$ heroku pg:promote HEROKU_POSTGRESQL_IVORY_URL -a mighty-mesa-1351
Ensuring an alternate alias for existing DATABASE... done, HEROKU_POSTGRESQL_AQUA
Promoting reading-fleetingly-3902 to DATABASE_URL on mighty-mesa-1351... done
```

The resource behind `DATABASE` had no other attachments, so it created `HEROKU_POSTGRESQL_AQUA` so that it could be replaced. I think this change is good, however it does have one rather large caveat which could affect users of the `preboot` labs feature in particular: it creates 2 releases (one to add an attachment, the other to replace an attachment) which could trigger 2 subsequent restarts. ccing @heroku/department-of-data for comment here.

We could alternatively pursue improvements to the error message that indicate the action that the user can take for correction. However, such an action would also cause 2 restarts.