### PR TITLE
Fix plugins command help output

### DIFF
--- a/lib/heroku/command/plugins.rb
+++ b/lib/heroku/command/plugins.rb
@@ -106,7 +106,7 @@ module Heroku::Command
       end
     end
 
-    # heroku plugins:link [PATH]
+    # plugins:link [PATH]
     # Links a local plugin into CLI.
     # This is useful when developing plugins locally.
     # It simply symlinks the specified path into ~/.heroku/node_modules


### PR DESCRIPTION
This PR removes the redundant `heroku` word here (in "Additional commands" section):
```
→ heroku help plugins
Usage: heroku plugins

 list installed plugins

Example:

 $ heroku plugins
 === Installed Plugins
 heroku-production-check@0.2.0

Additional commands, type "heroku help COMMAND" for more details:

  heroku plugins:link [PATH]  #  This is useful when developing plugins locally.
  plugins:install URL         #  install a plugin
  plugins:uninstall PLUGIN    #  uninstall a plugin
  plugins:update [PLUGIN]     #  updates all plugins or a single plugin by name
```

And also, here:
```
→ heroku help plugins:link
Usage: heroku heroku plugins:link [PATH]
 Links a local plugin into CLI.
 This is useful when developing plugins locally.
 It simply symlinks the specified path into ~/.heroku/node_modules
Example:
 $ heroku plugins:link .
```