### PR TITLE
Fix displaying attachments by resource when resolving from attachment name

### DIFF
--- a/lib/heroku/helpers/addons/display.rb
+++ b/lib/heroku/helpers/addons/display.rb
@@ -35,7 +35,7 @@ module Heroku::Helpers
         display("") # separate sections
 
         styled_header("Attachments")
-        display_attachments(get_attachments(:resource => identifier), ['App', 'Name'])
+        display_attachments(get_attachments(:resource => resource['id']), ['App', 'Name'])
       end
 
       # Shows all add-ons owned by and attachments attached to the provided app. For example:


### PR DESCRIPTION
Previously:

```sh-session
$ heroku addons --resource bjeanes::DATABASE
=== Resource Info
Name:        budding-busily-2230
Plan:        heroku-postgresql:dev
Billing App: bjeanes
Price:       free

=== Attachments
 !    Couldn't find that add-on.
```

Now:

``` sh-session
$ heroku addons --resource bjeanes::DATABASE
=== Resource Info
Name:        budding-busily-2230
Plan:        heroku-postgresql:dev
Billing App: bjeanes
Price:       free

=== Attachments
App      Name
-------  -------------------------
bjeanes  DATABASE
bjeanes  HEROKU_POSTGRESQL_CRIMSON
```