### PR TITLE
Dont hide DATABASE_URL from pg info if only attachment

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -529,7 +529,8 @@ private
     @resolver = generate_resolver
     dbs = @resolver.all_databases
 
-    unique_dbs = dbs.reject { |config, att| 'DATABASE_URL' == config }.map{|config, att| att}.compact
+    has_promoted = dbs.any? { |_, att| att.primary_attachment? }
+    unique_dbs = dbs.reject { |var, _| has_promoted && 'DATABASE_URL' == var }.map{|_, att| att}.compact
 
     db_infos = {}
     mutex = Mutex.new

--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -108,7 +108,8 @@ module Heroku::Helpers::HerokuPostgresql
         }
       @hpg_databases = Hash[ pairs ]
 
-      if find_database_url_real_attachment
+      # TODO: don't bother doing this if DATABASE_URL is already present in hash!
+      if !@hpg_databases.key?('DATABASE_URL') && find_database_url_real_attachment
         @hpg_databases['DATABASE_URL'] = find_database_url_real_attachment
       end
 


### PR DESCRIPTION
Fixes issue where `DATABASE_URL` is hidden from `heroku pg:info` when it is the only attachment to an add-on (see https://support.heroku.com/tickets/237195 for an example). This only hides the `DATABASE_URL` if something else has been detected as being an alias for the same add-on.

cc @gregburek @stevo550 @heroku/add-ons.

---

Ideally, this command (and others) would be resource-based instead of attachment-based to be aligned with the general add-ons model and to be more resilient to the types of attachment topologies that can now arise with the new primitives exposed.  

With those further changes, output might look something like this, instead (*speculative; not part of this PR*):

``` sh-session
$ heroku pg:info
=== glistening-goldly-8123
Aliases:     DATABASE, HEROKU_POSTGRESQL_CYAN 
Plan:        Hobby-dev
Status:      Available
Connections: 0/20
PG Version:  9.4.1
Created:     2015-05-13 05:42 UTC
Data Size:   6.4 MB
Tables:      0
Rows:        0/10000 (In compliance)
Fork/Follow: Unsupported
Rollback:    Unsupported

=== shining-sweetly-1354
Aliases:     HEROKU_POSTGRESQL_BLACK
Plan:        Hobby-dev
Status:      Available
Connections: 0/20
PG Version:  9.4.1
Created:     2015-05-13 05:42 UTC
Data Size:   6.4 MB
Tables:      0
Rows:        0/10000 (In compliance)
Fork/Follow: Unsupported
Rollback:    Unsupported

$ heroku pg:info CYAN
=== glistening-goldly-8123
Aliases:     DATABASE, HEROKU_POSTGRESQL_CYAN 
Plan:        Hobby-dev
Status:      Available
Connections: 0/20
PG Version:  9.4.1
Created:     2015-05-13 05:42 UTC
Data Size:   6.4 MB
Tables:      0
Rows:        0/10000 (In compliance)
Fork/Follow: Unsupported
Rollback:    Unsupported

$ heroku pg:info shining-sweetly-1354
=== shining-sweetly-1354
Aliases:     HEROKU_POSTGRESQL_BLACK
Plan:        Hobby-dev
Status:      Available
Connections: 0/20
PG Version:  9.4.1
Created:     2015-05-13 05:42 UTC
Data Size:   6.4 MB
Tables:      0
Rows:        0/10000 (In compliance)
Fork/Follow: Unsupported
Rollback:    Unsupported
```

If @heroku/department-of-data is OK with `pg:info` changing in this way, I can explore making the change.