### PR TITLE
Add --force-colors to logs command

### DIFF
--- a/lib/heroku/command/logs.rb
+++ b/lib/heroku/command/logs.rb
@@ -13,6 +13,7 @@ class Heroku::Command::Logs < Heroku::Command::Base
   # -p, --ps PS          # only display logs from the given process
   # -s, --source SOURCE  # only display logs from the given source
   # -t, --tail           # continually stream logs
+  # --force-colors       # Force use of ANSI color characters (even on non-tty outputs)
   #
   #Example:
   #
@@ -29,7 +30,7 @@ class Heroku::Command::Logs < Heroku::Command::Base
     opts << "ps=#{URI.encode(options[:ps])}"         if options[:ps]
     opts << "source=#{URI.encode(options[:source])}" if options[:source]
 
-    log_displayer = ::Heroku::Helpers::LogDisplayer.new(heroku, app, opts)
+    log_displayer = ::Heroku::Helpers::LogDisplayer.new(heroku, app, opts, options[:force_colors])
     log_displayer.display_logs
   end
 

--- a/spec/heroku/command/logs_spec.rb
+++ b/spec/heroku/command/logs_spec.rb
@@ -54,7 +54,19 @@ STDOUT
 STDOUT
         ENV["TERM"] = term
       end
+
+      it "uses ansi if --force-colors is passed, even if stdout is not a tty and TERM is not set" do
+        old_term = ENV.delete("TERM")
+        old_stdout_isatty = $stdout.isatty
+        stub($stdout).isatty.returns(false)
+        stderr, stdout = execute("logs --force-colors")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+\e[36m2011-01-01T00:00:00+00:00 app[web.1]:\e[0m test
+STDOUT
+        ENV["TERM"] = old_term
+        stub($stdout).isatty.returns(old_stdout_isatty)
+      end
     end
   end
-
 end


### PR DESCRIPTION
So we can `grep -v` and still have colors for exemple \o/

Thanks to @freeformz for the tips on Twitter