### PR TITLE
Domain CNAME Targets

### DIFF
--- a/lib/heroku/api/domains_v3_domain_cname.rb
+++ b/lib/heroku/api/domains_v3_domain_cname.rb
@@ -12,5 +12,18 @@ module Heroku
         }
       )
     end
+
+    def post_domains_v3_domain_cname(app, hostname)
+      request(
+        :expects => 201,
+        :method  => :post,
+        :path    => "/apps/#{app}/domains",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname",
+          "Content-Type" => "application/json"
+        },
+        body: Heroku::Helpers.json_encode({'hostname' => hostname})
+      )
+    end
   end
 end

--- a/lib/heroku/api/domains_v3_domain_cname.rb
+++ b/lib/heroku/api/domains_v3_domain_cname.rb
@@ -1,0 +1,16 @@
+module Heroku
+  class API
+    # TODO: rename methods and filename after 3.domain-cname is merged
+
+    def get_domains_v3_domain_cname(app)
+      request(
+        :expects => 200,
+        :method  => :get,
+        :path    => "/apps/#{app}/domains",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname"
+        }
+      )
+    end
+  end
+end

--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -48,14 +48,19 @@ module Heroku::Command
     # $ heroku domains:add example.com
     # Adding example.com to example... done
     #
+    # !   Configure your application’s DNS to point to example.herokudns.com
+    # !   For help with custom domains, see https://devcenter.heroku.com/articles/custom-domains
+    #
     def add
       unless domain = shift_argument
         error("Usage: heroku domains:add DOMAIN\nMust specify DOMAIN to add.")
       end
       validate_arguments!
-      action("Adding #{domain} to #{app}") do
-        api.post_domain(app, domain)
+      domain = action("Adding #{domain} to #{app}") do
+        api.post_domains_v3_domain_cname(app, domain).body
       end
+      output_with_bang "Configure your application's DNS to point to #{domain['cname']}"
+      output_with_bang "For help, see https://devcenter.heroku.com/articles/custom-domains"
     end
 
     # domains:remove DOMAIN

--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -18,7 +18,7 @@ module Heroku::Command
     # example.herokuapp.com
     #
     # === Custom Domains
-    # Domain Name  CNAME Target
+    # Domain Name  DNS Target
     # -----------  ---------------------
     # example.com  example.herokudns.com
     #
@@ -39,7 +39,7 @@ module Heroku::Command
       styled_header("Custom Domains")
       custom_domains = domains.select{ |d| d['kind'] == 'custom' }
       if custom_domains.length > 0
-        display_table(custom_domains, ['hostname', 'cname'], ['Domain Name', 'CNAME Target'])
+        display_table(custom_domains, ['hostname', 'cname'], ['Domain Name', 'DNS Target'])
       else
         display("#{app} has no custom domains.")
         display("Use `heroku domains:add DOMAIN` to add one.")

--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -27,15 +27,22 @@ module Heroku::Command
       domains = api.get_domains_v3_domain_cname(app).body
 
       styled_header("Development Domain")
-      display domains.detect{ |d| d['kind'] == 'default' }['hostname']
+      default_domain = domains.detect { |d| d['kind'] == 'default' }
+      if default_domain
+        display default_domain['hostname']
+      else
+        output_with_bang "Not found"
+      end
+
       display
 
+      styled_header("Custom Domains")
       custom_domains = domains.select{ |d| d['kind'] == 'custom' }
       if custom_domains.length > 0
-        styled_header("Custom Domains")
         display_table(custom_domains, ['hostname', 'cname'], ['Domain Name', 'CNAME Target'])
       else
-        display("#{app} has no custom domain names.")
+        display("#{app} has no custom domains.")
+        display("Use `heroku domains:add DOMAIN` to add one.")
       end
     end
 

--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -1,4 +1,5 @@
 require "heroku/command/base"
+require "heroku/api/domains_v3_domain_cname"
 
 module Heroku::Command
 
@@ -13,17 +14,28 @@ module Heroku::Command
     #Examples:
     #
     # $ heroku domains
-    # === Domain names for example
-    # example.com
+    # === Development Domain
+    # example.herokuapp.com
+    #
+    # === Custom Domains
+    # Domain Name  CNAME Target
+    # -----------  ---------------------
+    # example.com  example.herokudns.com
     #
     def index
       validate_arguments!
-      domains = api.get_domains(app).body
-      if domains.length > 0
-        styled_header("#{app} Domain Names")
-        styled_array domains.map {|domain| domain["domain"]}
+      domains = api.get_domains_v3_domain_cname(app).body
+
+      styled_header("Development Domain")
+      display domains.detect{ |d| d['kind'] == 'default' }['hostname']
+      display
+
+      custom_domains = domains.select{ |d| d['kind'] == 'custom' }
+      if custom_domains.length > 0
+        styled_header("Custom Domains")
+        display_table(custom_domains, ['hostname', 'cname'], ['Domain Name', 'CNAME Target'])
       else
-        display("#{app} has no domain names.")
+        display("#{app} has no custom domain names.")
       end
     end
 

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -25,11 +25,19 @@ module Heroku::Command
         :path => '/apps/example/domains') do
         {
           :body => (
-            [{ 'kind' => 'default', 'hostname' => 'example.herokuapp.com', 'cname' => nil }] +
-            custom_hostnames.map { |hostname|
-                { 'kind' => 'custom',  'hostname' => hostname, 'cname' => 'example.herokudns.com' }
-              }
-            ).to_json,
+          [
+            {
+              'kind' => 'default',
+              'hostname' => 'example.herokuapp.com',
+              'cname' => nil
+            }
+          ] + custom_hostnames.map { |hostname|
+            { 'kind' => 'custom',
+              'hostname' => hostname,
+              'cname' => 'example.herokudns.com'
+            }
+          }
+          ).to_json,
         }
       end
     end
@@ -37,15 +45,19 @@ module Heroku::Command
     # TODO: rename after 3.domain-cname is merged
     def stub_post_domains_v3_domain_cname(custom_hostname)
       Excon.stub(
-      :headers => {
-        "Accept" => "application/vnd.heroku+json; version=3.domain-cname",
-        "Content-Type" => "application/json"
-      },
-      :method => :post,
-      :path => '/apps/example/domains') do
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname",
+          "Content-Type" => "application/json"
+        },
+        :method => :post,
+        :path => '/apps/example/domains') do
         {
           :status => 201,
-          :body => { 'kind' => 'custom',  'hostname' => custom_hostname, 'cname' => 'example.herokudns.com' }.to_json,
+          :body => {
+            'kind' => 'custom',
+            'hostname' => custom_hostname,
+            'cname' => 'example.herokudns.com'
+          }.to_json,
         }
       end
     end

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -64,7 +64,22 @@ module Heroku::Command
 
     context("index") do
 
-      it "lists message with no custom domains" do
+      it "lists message with no domains" do
+        Excon.stub(:path => '/apps/example/domains') {{ :body => [].to_json }}
+
+        stderr, stdout = execute("domains")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+=== Development Domain
+ !    Not found
+
+=== Custom Domains
+example has no custom domains.
+Use `heroku domains:add DOMAIN` to add one.
+STDOUT
+      end
+
+      it "lists message with development domain but no custom domains" do
         stub_get_domains_v3_domain_cname()
         stderr, stdout = execute("domains")
         expect(stderr).to eq("")
@@ -72,11 +87,13 @@ module Heroku::Command
 === Development Domain
 example.herokuapp.com
 
-example has no custom domain names.
+=== Custom Domains
+example has no custom domains.
+Use `heroku domains:add DOMAIN` to add one.
 STDOUT
       end
 
-      it "lists domains when some exist" do
+      it "lists development and custom domains when some exist" do
         stub_get_domains_v3_domain_cname('example1.com', 'example2.com')
         stderr, stdout = execute("domains")
         expect(stderr).to eq("")

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -102,7 +102,7 @@ STDOUT
 example.herokuapp.com
 
 === Custom Domains
-Domain Name   CNAME Target
+Domain Name   DNS Target
 ------------  ---------------------
 example1.com  example.herokudns.com
 example2.com  example.herokudns.com


### PR DESCRIPTION
This change adds the following:
 - Splits the domains output into two tables for the standard `Development Domain` and `Custom Domains` (matching pending changes in Dashboard)
 - Adds a new `CNAME Target` column for custom domains
 - Adds instructions to use CNAME target when adding a custom domain
 - Uses `v3.domain-cname` variant for the commands above

cc: @dickeyxxx @tim-lang @itchymutt 