### PR TITLE
Identifying the cause of duplicate entries in `pg:info`

### DIFF
--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -109,6 +109,11 @@ module Heroku::Helpers::HerokuPostgresql
       @hpg_databases = Hash[ pairs ]
 
       # TODO: don't bother doing this if DATABASE_URL is already present in hash!
+      # CB: this line is falsing from cb-rails 3 because i do have a DATABASE_URL attachment
+      # so it doesn't resolve to real
+      # Looks like the API is returning the DATABASE_URL as a separate attachment
+      # than the color attachment
+      # the UUIDs are different, but it's the same ["resource"]["id"]
       if !@hpg_databases.key?('DATABASE_URL') && find_database_url_real_attachment
         @hpg_databases['DATABASE_URL'] = find_database_url_real_attachment
       end

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -10,7 +10,8 @@ module Heroku::Command
       api.put_config_vars "example", {
         "DATABASE_URL" => "postgres://database_url",
         "HEROKU_POSTGRESQL_IVORY_URL" => "postgres://database_url",
-        "HEROKU_POSTGRESQL_RONIN_URL" => "postgres://ronin_database_url"
+        "HEROKU_POSTGRESQL_RONIN_URL" => "postgres://ronin_database_url",
+        'HEROKU_POSTGRESQL_FOLLOW_URL' => "postgres://follow_database_url"
       }
 
       any_instance_of(Heroku::Helpers::HerokuPostgresql::Resolver) do |pg|
@@ -19,6 +20,13 @@ module Heroku::Command
             'app' => {'name' => 'sushi'},
             'name' => 'HEROKU_POSTGRESQL_IVORY',
             'config_var' => 'HEROKU_POSTGRESQL_IVORY_URL',
+            'resource' => {'name'  => 'loudly-yelling-1232',
+                           'value' => 'postgres://database_url',
+                           'type'  => 'heroku-postgresql:ronin' }}),
+          Heroku::Helpers::HerokuPostgresql::Attachment.new({
+            'app' => {'name' => 'sushi'},
+            'name' => 'DATABASE_URL',
+            'config_var' => 'DATABASE',
             'resource' => {'name'  => 'loudly-yelling-1232',
                            'value' => 'postgres://database_url',
                            'type'  => 'heroku-postgresql:ronin' }}),


### PR DESCRIPTION
Some customers have seen the same thing I've seen on my own app, where `DATABASE_URL` is set to `HEROKU_POSTGRESQL_COBALT_URL`:

```
~/Code/heroku (cb-database-url) ▸ be bin/heroku pg:info -a cb-rails3
=== DATABASE_URL
Plan:               Standard 0
Status:             Available
Data Size:          7.1 MB
Tables:             1
PG Version:         9.3.5
Connections:        2/120
Fork/Follow:        Available
Rollback:           earliest from 2015-06-04 01:01 UTC
Created:            2015-02-09 21:44 UTC
Forks:              HEROKU_POSTGRESQL_AQUA
Maintenance:        not required
Maintenance window: Thursdays 23:00 to Fridays 03:00 UTC

=== HEROKU_POSTGRESQL_AQUA_URL
Plan:               Standard 0
Status:             Available
Data Size:          7.1 MB
Tables:             0
PG Version:         9.3.6
Connections:        2/120
Fork/Follow:        Available
Rollback:           earliest from 2015-06-04 01:01 UTC
Created:            2015-04-08 16:00 UTC
Forked From:        HEROKU_POSTGRESQL_COBALT
Maintenance:        not required
Maintenance window: Tuesdays 19:30 to 23:30 UTC
...
=== HEROKU_POSTGRESQL_COBALT_URL
Plan:               Standard 0
Status:             Available
Data Size:          7.1 MB
Tables:             1
PG Version:         9.3.5
Connections:        2/120
Fork/Follow:        Available
Rollback:           earliest from 2015-06-04 01:01 UTC
Created:            2015-02-09 21:44 UTC
Forks:              HEROKU_POSTGRESQL_AQUA
Maintenance:        not required
Maintenance window: Thursdays 23:00 to Fridays 03:00 UTC
```

Which is to say, the same database is listed twice in the output: once under COBALT, and once under DATABASE. The expected behavior here is one entry, with a heading of `HEROKU_POSTGRESQL_COBALT_URL (DATABASE_URL)`.

As best I can tell, the dupe is coming back from the API. I was able to trace the difference in the spec and the real output back to the place I inserted those comments; in other words, `@hpg_databases`, which is lightly restructured data straight from the API, includes two different resources in the hash. They have different UUIDs but all the rest of the info is the same.

I updated the spec to try to better represent the data coming back from the API. That said, I have no idea how best to fix it, or else I would have. :)

cc @tef, and anyone else that I should add?