### PR TITLE
Now using HTTPS :sparkles:

### DIFF
--- a/tasks/exe.rake
+++ b/tasks/exe.rake
@@ -44,7 +44,7 @@ end
 def cache_file_from_bucket(filename)
   FileUtils.mkdir_p $cache_path
   file_cache_path = File.join($cache_path, filename)
-  system "curl -# http://heroku-toolbelt.s3.amazonaws.com/#{filename} -o '#{file_cache_path}'" unless File.exists? file_cache_path
+  system "curl -# https://heroku-toolbelt.s3.amazonaws.com/#{filename} -o '#{file_cache_path}'" unless File.exists? file_cache_path
   file_cache_path
 end
 

--- a/tasks/pkg.rake
+++ b/tasks/pkg.rake
@@ -35,13 +35,13 @@ file dist("heroku-toolbelt-#{version}.pkg") => distribution_files("pkg") do |t|
     end
 
     unless File.exists?(dist('foreman-0.75.0.pkg'))
-      sh %{ curl http://heroku-toolbelt.s3.amazonaws.com/foreman-0.75.0.pkg -o #{dist('foreman-0.75.0.pkg')} }
+      sh %{ curl https://heroku-toolbelt.s3.amazonaws.com/foreman-0.75.0.pkg -o #{dist('foreman-0.75.0.pkg')} }
     end
     sh %{ pkgutil --expand #{dist('foreman-0.75.0.pkg')} foreman }
     mv "foreman/foreman.pkg", "pkg/foreman.pkg"
 
     unless File.exists?(dist('ruby.pkg'))
-      sh %{ curl http://heroku-toolbelt.s3.amazonaws.com/ruby.pkg -o #{dist('ruby.pkg')} }
+      sh %{ curl https://heroku-toolbelt.s3.amazonaws.com/ruby.pkg -o #{dist('ruby.pkg')} }
     end
     sh %{ pkgutil --expand #{dist('ruby.pkg')} ruby }
     mv "ruby/ruby-1.9.3-p194.pkg", "pkg/ruby.pkg"


### PR DESCRIPTION
Unless there is a clear case where we shouldn't make use of HTTPS, we should use HTTPS.

Historically, the only reason I can think of where HTTP would have been the choice is where there were cert conflicts. @dickeyxxx are you aware of any cases where https didn't work?