### PR TITLE
make ps:scale automatically switch tiers

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -572,5 +572,10 @@ module Heroku
     def warn_if_using_jruby
       stderr_puts "WARNING: jruby is known to cause issues when used with the toolbelt." if RUBY_PLATFORM == "java"
     end
+
+    # cheap deep clone
+    def deep_clone(obj)
+      json_decode(json_encode(obj))
+    end
   end
 end

--- a/spec/heroku/command/ps_spec.rb
+++ b/spec/heroku/command/ps_spec.rb
@@ -273,6 +273,7 @@ STDOUT
     describe "ps:scale" do
 
       it "can scale using key/value format" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub({ :method => :patch, :path => "/apps/example/formation" },
                    { :body => [{"quantity" => "5", "size" => "1X", "type" => "web"}],
                      :status => 200})
@@ -284,6 +285,7 @@ STDOUT
       end
 
       it "can scale relative amounts" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub({ :method => :patch, :path => "/apps/example/formation" },
                    { :body => [{"quantity" => "3", "size" => "1X", "type" => "web"}],
                      :status => 200})
@@ -295,11 +297,12 @@ STDOUT
       end
 
       it "can resize while scaling" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub(
           {
             :method => :patch, :path => "/apps/example/formation",
             :body => {
-              "updates" => [{"process" => "web", "quantity" => "4", "size" => "2X"}]
+              "updates" => [{"process" => "web", "quantity" => 4, "size" => "2X"}]
             }.to_json
           },
           :body => [{"quantity" => 4, "size" => "2X", "type" => "web"}],
@@ -313,13 +316,14 @@ STDOUT
       end
 
       it "can scale multiple types in one call" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub(
           {
             :method => :patch, :path => "/apps/example/formation",
             :body => {
               "updates" => [
-                {"process" => "web",    "quantity" => "4", "size" => "1X"},
-                {"process" => "worker", "quantity" => "2", "size" => "2x"},
+                {"process" => "web",    "quantity" => 4, "size" => "1X"},
+                {"process" => "worker", "quantity" => 2, "size" => "2x"},
               ]
             }.to_json
           },
@@ -338,11 +342,12 @@ STDOUT
       end
 
       it "accepts PX as a valid size" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub(
           {
             :method => :patch, :path => "/apps/example/formation",
             :body => {
-              "updates" => [{"process" => "web", "quantity" => "4", "size" => "PX"}]
+              "updates" => [{"process" => "web", "quantity" => 4, "size" => "PX"}]
             }.to_json
           },
           :body => [{"quantity" => 4, "size" => "PX", "type" => "web"}],


### PR DESCRIPTION
In general, users shouldn't have to be aware of tiers and just be able
to switch between types no matter what tier the type belongs to.

This makes ps:scale automatically switch between tiers when using
ps:scale to change dyno types.

The one exception to this is that if there are existing dynos the user
isn't transferring to a new type, we don't want to change the tier and
effectively move *all* of their dynos to the lowest level on the new
tier.

This change will check to see if the user is trying to enter a state
like that with some dynos on one tier and some dynos on another and
error out.

Wherever possible the code will simply continue to the API and allow it
to show errors rather than add additional validation on the CLI which
may be too strict.