### PR TITLE
Only split the command by one ':' to separate topic from command.

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -8,7 +8,7 @@ class Heroku::JSPlugin
   end
 
   def self.try_takeover(command, args)
-    topic, cmd = command.split(':')
+    topic, cmd = command.split(':', 1)
     if cmd
       command = commands.find { |t| t["topic"] == topic && t["command"] == cmd }
     else


### PR DESCRIPTION
This is useful for nested commands.

```
'a:b:c' => { topic: 'a', command: 'b:c' }
```

This seems to be the behavior we get everywhere else. Maybe not a lot of
commands are nested but we start using a second level of nesting.