### PR TITLE
Domains Update

### DIFF
--- a/lib/heroku/api/domains_v3_domain_cname.rb
+++ b/lib/heroku/api/domains_v3_domain_cname.rb
@@ -1,0 +1,29 @@
+module Heroku
+  class API
+    # TODO: rename methods and filename after 3.domain-cname is merged
+
+    def get_domains_v3_domain_cname(app)
+      request(
+        :expects => 200,
+        :method  => :get,
+        :path    => "/apps/#{app}/domains",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname"
+        }
+      )
+    end
+
+    def post_domains_v3_domain_cname(app, hostname)
+      request(
+        :expects => 201,
+        :method  => :post,
+        :path    => "/apps/#{app}/domains",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname",
+          "Content-Type" => "application/json"
+        },
+        body: Heroku::Helpers.json_encode({'hostname' => hostname})
+      )
+    end
+  end
+end

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -17,37 +17,109 @@ module Heroku::Command
       stub_core
     end
 
+    # TODO: rename after 3.domain-cname is merged
+    def stub_get_domains_v3_domain_cname(*custom_hostnames)
+      Excon.stub(
+        :headers => { "Accept" => "application/vnd.heroku+json; version=3.domain-cname" },
+        :method => :get,
+        :path => '/apps/example/domains') do
+        {
+          :body => (
+          [
+            {
+              'kind' => 'heroku',
+              'hostname' => 'example.herokuapp.com',
+              'cname' => nil
+            }
+          ] + custom_hostnames.map { |hostname|
+            { 'kind' => 'custom',
+              'hostname' => hostname,
+              'cname' => 'example-2121.herokussl.com'
+            }
+          }
+          ).to_json,
+        }
+      end
+    end
+
+    # TODO: rename after 3.domain-cname is merged
+    def stub_post_domains_v3_domain_cname(custom_hostname)
+      Excon.stub(
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.domain-cname",
+          "Content-Type" => "application/json"
+        },
+        :method => :post,
+        :path => '/apps/example/domains') do
+        {
+          :status => 201,
+          :body => {
+            'kind' => 'custom',
+            'hostname' => custom_hostname,
+            'cname' => 'example-2121.herokussl.com'
+          }.to_json,
+        }
+      end
+    end
+
     context("index") do
 
       it "lists message with no domains" do
+        Excon.stub(:path => '/apps/example/domains') {{ :body => [].to_json }}
+
         stderr, stdout = execute("domains")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
-example has no domain names.
+=== example Heroku Domain
+ !    Not found
+
+=== example Custom Domains
+example has no custom domains.
+Use `heroku domains:add DOMAIN` to add one.
 STDOUT
       end
 
-      it "lists domains when some exist" do
-        api.post_domain("example", "example.com")
+      it "lists message with development domain but no custom domains" do
+        stub_get_domains_v3_domain_cname()
         stderr, stdout = execute("domains")
         expect(stderr).to eq("")
         expect(stdout).to eq <<-STDOUT
-=== example Domain Names
-example.com
+=== example Heroku Domain
+example.herokuapp.com
 
+=== example Custom Domains
+example has no custom domains.
+Use `heroku domains:add DOMAIN` to add one.
 STDOUT
-        api.delete_domain("example", "example.com")
+      end
+
+      it "lists development and custom domains when some exist" do
+        stub_get_domains_v3_domain_cname('example1.com', 'example2.com')
+        stderr, stdout = execute("domains")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+=== example Heroku Domain
+example.herokuapp.com
+
+=== example Custom Domains
+Domain Name   DNS Target
+------------  --------------------------
+example1.com  example-2121.herokussl.com
+example2.com  example-2121.herokussl.com
+STDOUT
       end
 
     end
 
     it "adds domain names" do
+      stub_post_domains_v3_domain_cname('example.com')
       stderr, stdout = execute("domains:add example.com")
       expect(stderr).to eq("")
       expect(stdout).to eq <<-STDOUT
 Adding example.com to example... done
+ !    Configure your app's DNS provider to point to the DNS Target example-2121.herokussl.com
+ !    For help, see https://devcenter.heroku.com/articles/custom-domains
 STDOUT
-      api.delete_domain("example", "example.com")
     end
 
     it "shows usage if no domain specified for add" do


### PR DESCRIPTION
After much internal discussion and wordsmithing, this re-opens https://github.com/heroku/heroku/pull/1589. To re-cap, this changes the following:

 - Splits the domains output into two tables for the standard Heroku Domain and Custom Domains (matching changes in Dashboard)
 - Adds a new DNS Target column for custom domains
 - Adds instructions to use DNS Target when adding a custom domain
 - Uses v3.domain-cname variant for the commands above

There is also a Dev Center article (`custom-domains`) staged for this change. They should be deployed together.

cc: @dickeyxxx @tim-lang 