### PR TITLE
Merge DATABASE_URL with another alias in pg:info

### DIFF
--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -108,9 +108,16 @@ module Heroku::Helpers::HerokuPostgresql
         }
       @hpg_databases = Hash[ pairs ]
 
-      # TODO: don't bother doing this if DATABASE_URL is already present in hash!
-      if !@hpg_databases.key?('DATABASE_URL') && find_database_url_real_attachment
-        @hpg_databases['DATABASE_URL'] = find_database_url_real_attachment
+      if @hpg_databases.key?('DATABASE_URL')
+        db_url = @hpg_databases['DATABASE_URL'].url
+        other_name = @hpg_databases.detect do |var, att|
+          var != 'DATABASE_URL' && att.url == db_url
+        end
+
+        # Mark it as being same as DATABASE_URL
+        other_name[1].primary_attachment! if other_name
+      elsif (db_att = find_database_url_real_attachment)
+        @hpg_databases['DATABASE_URL'] = db_att
       end
 
       return @hpg_databases


### PR DESCRIPTION
Merge `DATABASE_URL` with another alias in `pg:info` if there is another name. Otherwise, continue to present it as a first normal attachment.

---

Addresses #1605 in the short term, but does not implement the new output discussed in that issue.

This fixes a regression introduced by #1564, which was designed to show `DATABASE_URL` in the output if the database had no other alias. Instead, it always showed `DATABASE_URL`, even when it was a supplementary name for a colour-based one. While that is more correct, it is also less familiar to customers and should be addressed directly, as discussed towards the end of #1605.

cc @chadbailey59 @neovintage @diwu1989 @stevo550 @heroku/add-ons 