### PR TITLE
Group attachments by resource in pg:info

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -647,23 +647,22 @@ class Heroku::Command::Pg < Heroku::Command::Base
     return @hpg_databases_with_info if @hpg_databases_with_info
 
     @resolver = generate_resolver
-    dbs = @resolver.all_databases
+    attachments = @resolver.all_databases
 
-    has_promoted = dbs.any? { |_, att| att.primary_attachment? }
-    unique_dbs = dbs.reject { |var, _| has_promoted && 'DATABASE_URL' == var }.map{|_, att| att}.compact
+    attachments_by_db = attachments.values.group_by(&:resource_name)
 
     db_infos = {}
     mutex = Mutex.new
-    threads = (0..unique_dbs.size-1).map do |i|
+    threads = attachments_by_db.map do |resource, attachments|
       Thread.new do
-        att = unique_dbs[i]
+        name = attachments.map(&:config_var).sort.join(', ')
         begin
-          info = hpg_info(att, options[:extended])
+          info = hpg_info(attachments.first, options[:extended])
         rescue
           info = nil
         end
         mutex.synchronize do
-          db_infos[att.display_name] = info
+          db_infos[name] = info
         end
       end
     end
@@ -674,7 +673,13 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
   def hpg_info(attachment, extended=false)
-    hpg_client(attachment).get_database(extended)
+    info = hpg_client(attachment).get_database(extended)
+
+    # TODO: Make this the section title and list the current `name` as an
+    # "Attachments" item here:
+    info[:info] << {"name" => "Add-on", "values" => [attachment.resource_name]}
+
+    info
   end
 
   def hpg_info_display(item)

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -677,9 +677,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
     # TODO: Make this the section title and list the current `name` as an
     # "Attachments" item here:
-    info[:info] << {"name" => "Add-on", "values" => [attachment.resource_name]}
-
-    info
+    info.merge(:info => info[:info] + [{"name" => "Add-on", "values" => [attachment.resource_name]}])
   end
 
   def hpg_info_display(item)

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -94,8 +94,9 @@ PG Version:  9.1.4
 Fork/Follow: Available
 Created:     2011-12-13 00:00 UTC
 Maintenance: not required
+Add-on:      whatever-something-2323
 
-=== HEROKU_POSTGRESQL_IVORY_URL (DATABASE_URL)
+=== HEROKU_POSTGRESQL_IVORY_URL, DATABASE_URL
 Plan:        Ronin
 Status:      available
 Data Size:   1 MB
@@ -104,6 +105,7 @@ PG Version:  9.1.4
 Fork/Follow: Available
 Created:     2011-12-13 00:00 UTC
 Maintenance: not required
+Add-on:      loudly-yelling-1232
 
 === HEROKU_POSTGRESQL_RONIN_URL
 Plan:        Ronin
@@ -114,6 +116,7 @@ PG Version:  9.1.4
 Fork/Follow: Available
 Created:     2011-12-13 00:00 UTC
 Maintenance: not required
+Add-on:      softly-mocking-123
 
 STDOUT
       end
@@ -146,6 +149,7 @@ Fork/Follow: Available
 Forked From: Database on postgreshost.com:5432/database_name
 Created:     2011-12-13 00:00 UTC
 Maintenance: not required
+Add-on:      softly-mocking-123
 
 STDOUT
       end


### PR DESCRIPTION
Bonus: this likely makes fewer requests for multiple attachments.

Alternate to #1643; closer to what was discussed with @neovintage and @chadbailey59 as per https://github.com/heroku/heroku/pull/1605#issuecomment-112475786.

Output, from specs:

```
=== HEROKU_POSTGRESQL_IVORY_URL, DATABASE_URL
Plan:        Ronin
Status:      available
Data Size:   1 MB
Tables:      1
PG Version:  9.1.4
Fork/Follow: Available
Created:     2011-12-13 00:00 UTC
Maintenance: not required
Add-on:      loudly-yelling-1232

=== HEROKU_POSTGRESQL_RONIN_URL
Plan:        Ronin
Status:      available
Data Size:   1 MB
Tables:      1
PG Version:  9.1.4
Fork/Follow: Available
Created:     2011-12-13 00:00 UTC
Maintenance: not required
Add-on:      softly-mocking-123
```

Importantly, it groups *all* attachments of the same add-on, only makes one request per *resource* to get the info, puts `DATABASE_URL` last still (though not in a parenthetical).

attn: @neovintage @chadbailey59 @stevo550 @heroku/add-ons 