### PR TITLE
Add space option to apps:create

### DIFF
--- a/lib/heroku/api/organizations_apps_v3_dogwood.rb
+++ b/lib/heroku/api/organizations_apps_v3_dogwood.rb
@@ -1,0 +1,15 @@
+module Heroku
+  class API
+    def post_organizations_app_v3_dogwood(params={})
+      request(
+        :method => :post,
+        :body => Heroku::Helpers.json_encode(params),
+        :expects => 201,
+        :path => "/organizations/apps",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.dogwood"
+        }
+      )
+    end
+  end
+end

--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -1,5 +1,6 @@
 require "heroku/command/base"
 require "heroku/command/stack"
+require "heroku/api/organizations_apps_v3_dogwood"
 
 # manage apps (create, destroy)
 #
@@ -195,6 +196,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
   # -b, --buildpack BUILDPACK  # a buildpack url to use for this app
   # -n, --no-remote            # don't create a git remote
   # -r, --remote REMOTE        # the git remote to create, default "heroku"
+  #     --space SPACE          # HIDDEN: the space in which to create the app
   # -s, --stack STACK          # the stack on which to create the app
   #     --region REGION        # specify region for this app to run in
   # -l, --locked               # lock the app
@@ -232,18 +234,22 @@ class Heroku::Command::Apps < Heroku::Command::Base
     params = {
       "name" => name,
       "region" => options[:region],
+      "space" => options[:space],
       "stack" => Heroku::Command::Stack::Codex.in(options[:stack]),
       "locked" => options[:locked]
     }
 
     info = if org
       org_api.post_app(params, org).body
+    elsif options[:space]
+      api.post_organizations_app_v3_dogwood(params).body
     else
       api.post_app(params).body
     end
 
     begin
-      action("Creating #{info['name']}", :org => !!org) do
+      space_action = info['space'] ? " in space #{info['space']['name']}" : ''
+      action("Creating #{info['name']}#{space_action}", :org => !!org) do
         if info['create_status'] == 'creating'
           Timeout::timeout(options[:timeout].to_i) do
             loop do

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -163,6 +163,35 @@ STDOUT
         api.delete_app("alternate-remote")
       end
 
+      it "with a space" do
+        Excon.stub(
+          :headers => { 'Accept' => 'application/vnd.heroku+json; version=3.dogwood'},
+          :method => :post,
+          :path => '/organizations/apps') do
+          {
+            :status => 201,
+            :body => {
+              :name => 'spaceapp',
+              :space => {
+                :name => 'example-space'
+              },
+              :stack => 'cedar-14',
+              :web_url => 'http://spaceapp.herokuapp.com/'
+            }.to_json,
+          }
+        end
+
+        with_blank_git_repository do
+          stderr, stdout = execute("apps:create spaceapp --space example-space")
+          expect(stderr).to eq("")
+          expect(stdout).to eq <<-STDOUT
+Creating spaceapp in space example-space... done, stack is cedar-14
+http://spaceapp.herokuapp.com/ | https://git.heroku.com/spaceapp.git
+Git remote heroku added
+          STDOUT
+        end
+      end
+
     end
 
     context("index") do


### PR DESCRIPTION
This adds a hidden `--space` option to the `apps:create` command as a first step for moving this off the `dapps` namespace. This still uses a variant until this endpoint is in the mainline API, but we have gotten enough negative feedback about having to use `dapps:create` to create apps in spaces that it is important to at least have this command in the mainline CLI. 

The only other command under `dapps` is `dapps:info`, which will be done separately because 1) it will require API changes and 2) it is less important.

/cc @tim-lang 