### PR TITLE
Add space attribute to apps:info

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -170,6 +170,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
       data["Owner Email"] = app_data["owner_email"] if app_data["owner_email"]
       data["Owner"] = app_data["owner"] if app_data["owner"]
       data["Region"] = app_data["region"] if app_data["region"]
+      data["Space"] = app_data["space"]["name"] if app_data["space"] && app_data["space"]["name"]
       data["Repo Size"] = format_bytes(app_data["repo_size"]) if app_data["repo_size"]
       data["Slug Size"] = format_bytes(app_data["slug_size"]) if app_data["slug_size"]
       data["Cache Size"] = format_bytes(app_data["cache_size"]) if app_data["cache_size"]


### PR DESCRIPTION
As a follow up to https://github.com/heroku/heroku/pull/1651, this displays the apps' spaces in `apps:info`. This is the last nail in the coffin for the `dapps` namespace. Note, this depends on https://github.com/heroku/api/pull/4464 being deployed; however, the deployment order does not matter since this will only display the attribute if it is present.  

/cc @tim-lang 