### PR TITLE
Explicitly block specifying both --space and --org when listing apps

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -29,6 +29,10 @@ class Heroku::Command::Apps < Heroku::Command::Base
     validate_arguments!
     options[:ignore_no_org] = true
 
+    if options[:space] && org
+      error "Specify option for space or org, but not both."
+    end
+
     apps = if options[:space]
       api.get_apps.body.select do |app|
         app["space"] && [app["space"]["name"], app["space"]["id"]].include?(options[:space])

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -331,6 +331,16 @@ STDOUT
       end
     end
 
+    context("index with space and org") do
+      it "displays error to not specify both" do
+        stderr, stdout = execute("apps --space test-space --org test-org")
+        expect(stdout).to eq("")
+        expect(stderr).to eq <<-STDERR
+ !    Specify option for space or org, but not both.
+STDERR
+      end
+    end
+
     context("rename") do
 
       context("success") do


### PR DESCRIPTION
Follow up to https://github.com/heroku/heroku/pull/1655

/cc @geemus 