### PR TITLE
Fix issues with backup scheduling

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -562,8 +562,10 @@ EOF
     # e.g., names like FOLLOWER_URL work. To do this, we look up the
     # app config vars and re-find one that looks like the user's
     # requested name.
-    db_name, alias_url = resolver.app_config_vars.find { |k,_| k =~ /#{db}/i }
-    if attachment.url != alias_url
+    db_name, alias_url = resolver.app_config_vars.find do |k,v|
+      k =~ /#{db}/i && v == attachment.url
+    end
+    if alias_url.nil?
       error("Could not find database to schedule for backups. Try using its full name.")
     end
 
@@ -628,7 +630,7 @@ EOF
   end
 
   def parse_schedule_time(time_str)
-    hour, tz = time_str.match(/([0-2][0-9]):00 (.*)/) && [ $1, $2 ]
+    hour, tz = time_str.match(/([0-2][0-9]):00 ?(.*)/) && [ $1, $2 ]
     if hour.nil? || tz.nil?
       abort("Invalid schedule format: expected '<hour>:00 <timezone>'")
     end

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -163,6 +163,63 @@ EOF
       end
     end
 
+    describe "heroku pg:backups schedule" do
+      before do
+        allow_any_instance_of(Heroku::Helpers::HerokuPostgresql::Resolver)
+          .to receive(:app_attachments).and_return(example_attachments)
+      end
+
+      it "schedules the requested database at the specified time" do
+        stub_pg.schedule({ hour: '07', timezone: 'UTC',
+                           schedule_name: 'HEROKU_POSTGRESQL_RED_URL' })
+        stderr, stdout = execute("pg:backups schedule RED --at 07:00UTC --app example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/Scheduled automatic daily backups/)
+      end
+
+      it "finds the right database when there are similarly-named databases" do
+        additional_attachment = Heroku::Helpers::HerokuPostgresql::Attachment
+                               .new({
+                                      'app' => {'name' => 'example'},
+                                      'name' => 'ALSO_HEROKU_POSTGRESQL_IVORY',
+                                      'config_var' => 'ALSO_HEROKU_POSTGRESQL_IVORY_URL',
+                                      'resource' => {'name'  => 'loudly-yelling-1239',
+                                                     'value' => 'postgres:///not-actually-ivory',
+                                                     'type'  => 'heroku-postgresql:standard-0' }})
+        example_attachments << additional_attachment
+        stub_pg.schedule({ hour: '07', timezone: 'UTC',
+                           schedule_name: 'HEROKU_POSTGRESQL_IVORY_URL' })
+        stderr, stdout = execute("pg:backups schedule HEROKU_POSTGRESQL_IVORY_URL --at 07:00UTC --app example")
+        expect(stderr).to be_empty
+        expect(stdout).to match(/Scheduled automatic daily backups/)
+      end
+
+      context "demonstrating cultural imperialism" do
+         {
+          'PST' => 'America/Los_Angeles',
+          'PDT' => 'America/Los_Angeles',
+          'MST' => 'America/Boise',
+          'MDT' => 'America/Boise',
+          'CST' => 'America/Chicago',
+          'CDT' => 'America/Chicago',
+          'EST' => 'America/New_York',
+          'EDT' => 'America/New_York',
+          'Z'   => 'UTC',
+          'GMT' => 'Europe/London',
+          'BST' => 'Europe/London',
+         }.each do |common_but_ambiguous_abbreviation, official_tz_db_name|
+           it "translates #{common_but_ambiguous_abbreviation} to #{official_tz_db_name}" do
+             stub_pg.schedule({ hour: '07', timezone: official_tz_db_name,
+                                schedule_name: 'HEROKU_POSTGRESQL_RED_URL' })
+             specified_time = "07:00#{common_but_ambiguous_abbreviation}"
+             stderr, stdout = execute("pg:backups schedule RED --at #{specified_time} --app example")
+             expect(stderr).to be_empty
+             expect(stdout).to match(/Scheduled automatic daily backups/)
+           end
+         end
+      end
+    end
+
     describe "heroku pg:backups unschedule" do
       let(:schedules) do
         [ { name: 'HEROKU_POSTGRESQL_GREEN_URL',

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -172,7 +172,7 @@ EOF
       it "schedules the requested database at the specified time" do
         stub_pg.schedule({ hour: '07', timezone: 'UTC',
                            schedule_name: 'HEROKU_POSTGRESQL_RED_URL' })
-        stderr, stdout = execute("pg:backups schedule RED --at 07:00UTC --app example")
+        stderr, stdout = execute("pg:backups schedule RED --at '07:00 UTC' --app example")
         expect(stderr).to be_empty
         expect(stdout).to match(/Scheduled automatic daily backups/)
       end
@@ -189,7 +189,7 @@ EOF
         example_attachments << additional_attachment
         stub_pg.schedule({ hour: '07', timezone: 'UTC',
                            schedule_name: 'HEROKU_POSTGRESQL_IVORY_URL' })
-        stderr, stdout = execute("pg:backups schedule HEROKU_POSTGRESQL_IVORY_URL --at 07:00UTC --app example")
+        stderr, stdout = execute("pg:backups schedule HEROKU_POSTGRESQL_IVORY_URL --at '07:00 UTC' --app example")
         expect(stderr).to be_empty
         expect(stdout).to match(/Scheduled automatic daily backups/)
       end
@@ -211,8 +211,8 @@ EOF
            it "translates #{common_but_ambiguous_abbreviation} to #{official_tz_db_name}" do
              stub_pg.schedule({ hour: '07', timezone: official_tz_db_name,
                                 schedule_name: 'HEROKU_POSTGRESQL_RED_URL' })
-             specified_time = "07:00#{common_but_ambiguous_abbreviation}"
-             stderr, stdout = execute("pg:backups schedule RED --at #{specified_time} --app example")
+             specified_time = "07:00 #{common_but_ambiguous_abbreviation}"
+             stderr, stdout = execute("pg:backups schedule RED --at '#{specified_time}' --app example")
              expect(stderr).to be_empty
              expect(stdout).to match(/Scheduled automatic daily backups/)
            end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require "rr"
 require "fakefs/safe"
 require 'tmpdir'
 require "webmock/rspec"
+require "shellwords"
 
 include WebMock::API
 
@@ -46,7 +47,7 @@ end
 def execute(command_line, opts={})
   extend RR::Adapters::RRMethods
 
-  args = command_line.split(" ")
+  args = command_line.shellsplit
   command = args.shift
 
   Heroku::Command.load


### PR DESCRIPTION
Previously, if another config var matches the user-provided alias but
its value does *not* match (e.g., the config var for the database the
user is trying to schedule is a substring of another config var with a
different value), we error out. This fixes that and adds specs around
backup scheduling.