### PR TITLE
Fix spaces with default org

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -27,8 +27,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   def index
     validate_arguments!
-    validate_space_xor_org!
     options[:ignore_no_org] = true
+    validate_space_xor_org!
 
     apps = if options[:space]
       api.get_apps.body.select do |app|
@@ -245,8 +245,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
   def create
     name    = shift_argument || options[:app] || ENV['HEROKU_APP']
     validate_arguments!
-    validate_space_xor_org!
     options[:ignore_no_org] = true
+    validate_space_xor_org!
 
     params = {
       "name" => name,

--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -253,6 +253,7 @@ module Heroku
     ## DISPLAY HELPERS
 
     def action(message, options={})
+      message = "#{message} in space #{options[:space]}" if options[:space]
       message = "#{message} in organization #{org}" if options[:org]
       display("#{message}... ", false)
       Heroku::Helpers.error_with_failure = true


### PR DESCRIPTION
This fixes the new apps's spaces commands to work with the `HEROKU_ORGANIZATION` env to set default org. The changes are as follows:

 - Users can explicitly specify `--space` or `--org`, but not both.
 - If the `HEROKU_ORGANIZATION` is set, it is ignored when using `--space`. The reason being that `--org` overrides `HEROKU_ORGANIZATION`, so `--space` (which is in an org) should too. In the future we might want to do something fancy where we look up the org from the space to reconcile these two, but since space names are globally unique, there's probably little reason users would want that.
 - Added `shared_examples` tests with and without a default org for app space commands. 

/cc @geemus @markpundsack 