### PR TITLE
Fix `heroku apps --space` to display unjoined apps

### DIFF
--- a/lib/heroku/api/spaces_v3_dogwood.rb
+++ b/lib/heroku/api/spaces_v3_dogwood.rb
@@ -1,0 +1,14 @@
+module Heroku
+  class API
+    def get_space_v3_dogwood(space_identity)
+      request(
+        :method => :get,
+        :expects => [200],
+        :path => "/spaces/#{space_identity}",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3.dogwood"
+        }
+      )
+    end
+  end
+end

--- a/lib/heroku/command/base.rb
+++ b/lib/heroku/command/base.rb
@@ -3,6 +3,7 @@ require "heroku/auth"
 require "heroku/client/rendezvous"
 require "heroku/client/organizations"
 require "heroku/command"
+require "heroku/api/spaces_v3_dogwood"
 
 class Heroku::Command::Base
   include Heroku::Helpers
@@ -41,7 +42,10 @@ class Heroku::Command::Base
     @nil = false
     options[:ignore_no_app] = true
 
-    @org ||= if options[:org].is_a?(String)
+    @org ||= if options[:space].is_a?(String)
+       validate_space_xor_org!
+       api.get_space_v3_dogwood(options[:space]).body['organization']['name']
+    elsif options[:org].is_a?(String)
       options[:org]
     elsif options[:personal] || @nil
       nil
@@ -56,6 +60,12 @@ class Heroku::Command::Base
 
     @nil = true if @org == nil
     @org
+  end
+
+  def validate_space_xor_org!
+    if options[:space] && options[:org]
+      error "Specify option for space or org, but not both."
+    end
   end
 
   def api

--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -253,9 +253,7 @@ module Heroku
     ## DISPLAY HELPERS
 
     def action(message, options={})
-      message = "#{message} in space #{options[:space]}" if options[:space]
-      message = "#{message} in organization #{org}" if options[:org]
-      display("#{message}... ", false)
+      display("#{in_message(message, options)}... ", false)
       Heroku::Helpers.error_with_failure = true
       ret = yield
       Heroku::Helpers.error_with_failure = false
@@ -266,6 +264,12 @@ module Heroku
       end
       display
       ret
+    end
+
+    def in_message(message, options={})
+      message = "#{message} in space #{options[:space]}" if options[:space]
+      message = "#{message} in organization #{org}" if options[:org]
+      message
     end
 
     def status(message)


### PR DESCRIPTION
This changes `heroku apps --space` to use the updated v2 org apps endpoint that now includes the space attribute. Unjoined apps in spaces are now displayed and the rest of the space query and display logic falls inline with orgs now. This also has the side benefit of validating space visibility to improve error messages for unauthorized access.

@geemus This fixes the issue I was talking about in https://github.com/heroku/heroku/pull/1667#issuecomment-124211467. I went with alternative 1 in API, and this is the corresponding CLI change. It unifies the space and org logic without introducing any new endpoints, so I think this is a win.

/cc @dickeyxxx 