### PR TITLE
Always display unjoined org apps

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -12,7 +12,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   # -o, --org ORG     # the org to list the apps for
   #     --space SPACE # HIDDEN: list apps in a given space
-  # -A, --all         # list all apps in the org. Not just joined apps
+  # -A, --all         # list all collaborated apps, including joined org apps in personal app list
   # -p, --personal    # list apps in personal account when a default org is set
   #
   #Example:
@@ -43,26 +43,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
 
     unless apps.empty?
       if org
-        joined, unjoined = apps.partition { |app| app['joined'] == true }
-
-        styled_header(in_message("Apps joined", app_in_msg_opts))
-        unless joined.empty?
-          styled_array(joined.map {|app| regionized_app_name(app) + (app['locked'] ? ' (locked)' : '') })
-        else
-          display("You haven't joined any apps.")
-          display("Use --all to see unjoined apps.") unless options[:all]
-          display
-        end
-
-        if options[:all]
-          styled_header(in_message("Apps available to join", app_in_msg_opts))
-          unless unjoined.empty?
-            styled_array(unjoined.map {|app| regionized_app_name(app) + (app['locked'] ? ' (locked)' : '') })
-          else
-            display("There are no apps to join.")
-            display
-          end
-        end
+        styled_header(in_message("Apps", app_in_msg_opts))
+        styled_array(apps.map {|app| regionized_app_name(app) + (app['locked'] ? ' (locked)' : '') })
       else
         my_apps, collaborated_apps = apps.partition { |app| app["owner_email"] == Heroku::Auth.user }
 

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -263,24 +263,12 @@ STDOUT
             )
           end
 
-          it "lists joined apps in an organization" do
+          it "list all in an organization" do
             stderr, stdout = execute("apps -o test-org")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
-=== Apps joined in organization test-org
+=== Apps in organization test-org
 org-app-1
-
-STDOUT
-          end
-
-          it "list all apps in an organization with the --all flag" do
-            stderr, stdout = execute("apps --all -o test-org")
-            expect(stderr).to eq("")
-            expect(stdout).to eq <<-STDOUT
-=== Apps joined in organization test-org
-org-app-1
-
-=== Apps available to join in organization test-org
 org-app-2
 
 STDOUT
@@ -325,13 +313,11 @@ STDOUT
           end
 
           it "lists only apps in spaces by name" do
-            stderr, stdout = execute("apps --space test-space --all")
+            stderr, stdout = execute("apps --space test-space")
             expect(stderr).to eq("")
             expect(stdout).to eq <<-STDOUT
-=== Apps joined in space test-space
+=== Apps in space test-space
 space-app-1
-
-=== Apps available to join in space test-space
 space-app-2
 
 STDOUT


### PR DESCRIPTION
**Note, the base for this PR is `space-apps-unjoined` for a clearer diff of the what's changing and to avoid a future merge conflict; however, it should be merged all the way to `master`.**

This changes the org app list to always display joined and unjoined apps together in one list for parity with Dashboard. Hiding and segregating unjoined apps has proved to confuse users.

This leaves the --all option in place, but updates the documentation to reflect what is actually does for the personal app list.

/cc @naaman @dickeyxxx 