### PR TITLE
Use same attachment for multiple invocations of exec_sql

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -758,8 +758,8 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
   def exec_sql(sql)
-    attachment = generate_resolver.resolve(shift_argument, "DATABASE_URL")
-    attachment.maybe_tunnel do |uri|
+    @attachment ||= generate_resolver.resolve(shift_argument, "DATABASE_URL")
+    @attachment.maybe_tunnel do |uri|
       exec_sql_on_uri(sql, uri)
     end
   end


### PR DESCRIPTION
Running pg:ps will execute two sql statements, one to determine the
database version and another to read pg_stat_activity. Two executions of
exec_sql will shift the supplied argument out, which leaves the defaul,
DATABASE_URL. This commit uses a cached class variable so that multiple
exec_sql calls will run on the first supplied database attachment.