### PR TITLE
Add option to copy config variables between apps

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -156,4 +156,25 @@ class Heroku::Command::Config < Heroku::Command::Base
 
   alias_command "config:remove", "config:unset"
 
+  # config:copy APP2
+  #
+  # copy config variables from one application to another
+  #
+  # $ heroku config:copy APP2 --APP1
+  # App1 config vars copied to APP2
+  #
+  def copy
+    requires_preauth
+
+    if args.empty?
+      error("Usage: heroku config:copy APP\nMust specify target application.")
+    end
+
+    vars = api.get_config_vars(app).body
+    api.put_config_vars(args.first, vars)
+    copied_vars = api.get_config_vars(args.first).body
+
+    display("#{app} config vars copied to #{args.first}")
+  end
+
 end

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -153,5 +153,24 @@ STDOUT
         end
       end
     end
+
+    describe "config:copy" do
+      it "exits with a help notice when target app is not provided" do
+        stderr, stdout = execute("config:copy")
+        expect(stderr).to eq <<-STDERR
+ !    Usage: heroku config:copy APP
+ !    Must specify target application.
+        STDERR
+      end
+
+      it "copies all config vars from example app to target app" do
+        stub_core
+        api.post_app("name" => "target_app", "stack" => "cedar")
+
+        stderr, stdout = execute("config:copy target_app")
+        expect(stdout).to eq "example config vars copied to target_app\n"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
When migrating an Application to another stack, Heroku's help page suggests to create a clone of that application in the new stack and test it. It is also required to copy the variables from that application.

Command:

`heroku config:copy target_app --app source_app`