### PR TITLE
Display current dyno formation with ps:scale

### DIFF
--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -348,7 +348,7 @@ class Heroku::Command::Ps < Heroku::Command::Base
   end
 
   def display_dyno_formation(formation)
-    dynos = formation.sort_by{|d| d['type']}.map{|d| "#{d['type']}=#{d['quantity']}:#{d['size']}"}
+    dynos = formation.map{|d| "#{d['type']}=#{d['quantity']}:#{d['size']}"}.sort
 
     if dynos.empty?
       error_no_process_types

--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -325,6 +325,10 @@ class Heroku::Command::Ps < Heroku::Command::Base
     )
   end
 
+  def error_no_process_types
+      error "No process types on #{app}.\nUpload a Procfile to add process types.\nhttps://devcenter.heroku.com/articles/procfile"
+  end
+
   def display_dyno_type_and_costs(formation)
     annotated = formation.sort_by{|d| d['type']}.map do |dyno|
       cost = COSTS[dyno["size"]]
@@ -337,7 +341,7 @@ class Heroku::Command::Ps < Heroku::Command::Base
     end
 
     if annotated.empty?
-      error "No process types on #{app}.\nUpload a Procfile to add process types.\nhttps://devcenter.heroku.com/articles/procfile"
+      error_no_process_types
     else
       display_table(annotated, annotated.first.keys, annotated.first.keys)
     end
@@ -347,7 +351,7 @@ class Heroku::Command::Ps < Heroku::Command::Base
     dynos = formation.sort_by{|d| d['type']}.map{|d| "#{d['type']}=#{d['quantity']}:#{d['size']}"}
 
     if dynos.empty?
-      error "No process types on #{app}.\nUpload a Procfile to add process types.\nhttps://devcenter.heroku.com/articles/procfile"
+      error_no_process_types
     else
       display dynos.join(" ")
     end

--- a/spec/heroku/command/ps_spec.rb
+++ b/spec/heroku/command/ps_spec.rb
@@ -272,6 +272,17 @@ STDOUT
 
     describe "ps:scale" do
 
+      it "displays existing dyno formation" do
+        Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [
+          {"quantity" => 1, "size" => "2X", "type" => "web"},
+          {"quantity" => 2, "size" => "1X", "type" => "worker"}], status: 200})
+        stderr, stdout = execute("ps:scale")
+        expect(stderr).to eq("")
+        expect(stdout).to eq <<-STDOUT
+web=1:2X worker=2:1X
+STDOUT
+      end
+
       it "can scale using key/value format" do
         Excon.stub({ method: :get, path: "/apps/example/formation" }, { body: [], status: 200})
         Excon.stub({ :method => :patch, :path => "/apps/example/formation" },


### PR DESCRIPTION
This is useful for deployment scripts, for example, that automatically scale everything down before a deploy with migrations, then scale everything back up the way it was before. This allows us to just use `ps:scale` to get the current formation and pass that string right back into `ps:scale` after the deploy is complete. Otherwise, we have to parse the output of `ps:type` to do the same thing.