### PR TITLE
make heroku-accounts warning much more obvious

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -267,7 +267,6 @@ class Heroku::Auth
     end
 
     def ask_for_and_save_credentials
-      warn "WARNING: heroku-accounts plugin is installed. This plugin is known to have problems with HTTP Git." if defined?(Heroku::Command::Accounts)
       @credentials = ask_for_credentials
       debug "Logged in as #{@credentials[0]} with key: #{@credentials[1][0,6]}..."
       write_credentials

--- a/lib/heroku/cli.rb
+++ b/lib/heroku/cli.rb
@@ -24,6 +24,7 @@ class Heroku::CLI
     require 'heroku/command'
     Heroku::Git.check_git_version
     Heroku::Command.load
+    warn_if_using_heroku_accounts
     Heroku::Command.run(command, args)
     Heroku::Updater.autoupdate
   rescue Errno::EPIPE => e
@@ -40,4 +41,7 @@ class Heroku::CLI
     exit(1)
   end
 
+  def self.warn_if_using_heroku_accounts
+    warn "WARNING: deprecated ddollar/heroku-accounts plugin is installed." if defined?(Heroku::Command::Accounts)
+  end
 end


### PR DESCRIPTION
It will not work with http-git or any new commands. It isn't being
maintained, but with how new commands work there isn't a way for the
plugin to function even if it had a maintainer.