### PR TITLE
Consolidate add on related output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :development, :test do
   gem "rspec"
   gem "webmock"
   gem "coveralls", :require => false
+  gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       mime-types
       xml-simple
     builder (3.2.2)
+    coderay (1.1.0)
     coveralls (0.8.0)
       multi_json (~> 1.10)
       rest-client (>= 1.6.8, < 2)
@@ -37,12 +38,17 @@ GEM
     json (1.8.2)
     launchy (2.4.3)
       addressable (~> 2.3)
+    method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.0)
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     netrc (0.10.3)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rdoc (4.2.0)
     rest-client (1.6.8)
@@ -69,6 +75,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
+    slop (3.6.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
@@ -88,6 +95,7 @@ DEPENDENCIES
   heroku!
   json
   mime-types
+  pry
   rake
   rr
   rspec

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -42,9 +42,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:info [DATABASE]
   #
-  #   -x, --extended  # Show extended information
-  #
   # display database information
+  #
+  #   -x, --extended  # Show extended information
   #
   # If DATABASE is not specified, displays all databases
   #
@@ -118,9 +118,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:psql [DATABASE]
   #
-  #  -c, --command COMMAND      # optional SQL command to run
-  #
   # open a psql shell to the database
+  #
+  #  -c, --command COMMAND      # optional SQL command to run
   #
   # defaults to DATABASE_URL databases if no DATABASE is specified
   #
@@ -501,7 +501,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:links <create|destroy>
   #
-  # Create links between data stores.  Without a subcommand, it lists all
+  # create links between data stores.  Without a subcommand, it lists all
   # databases and information on the link.
   #
   # create <REMOTE> <LOCAL>   # Create a data link

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -527,13 +527,15 @@ class Heroku::Command::Pg < Heroku::Command::Base
         dbs = resolver.all_databases.values
       end
 
+      dbs_by_addons = dbs.group_by(&:resource_name)
+
       error("No database attached to this app.") if dbs.compact.empty?
 
-      dbs.each_with_index do |attachment, index|
-        response = hpg_client(attachment).link_list
+      dbs_by_addons.each_with_index do |(resource, attachments), index|
+        response = hpg_client(attachments.first).link_list
         display "\n" if index.nonzero?
 
-        styled_header("#{attachment.display_name} (#{attachment.resource_name})")
+        styled_header("#{attachments.map(&:config_var).join(", ")} (#{resource})")
 
         next display response[:message] if response.kind_of?(Hash)
         next display "No data sources are linked into this database." if response.empty?

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -411,11 +411,11 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:maintenance <info|run|set-window> <DATABASE>
   #
-  #  manage maintenance for <DATABASE>
-  #  info               # show current maintenance information
-  #  run                # start maintenance
-  #    -f, --force      #   run pg:maintenance without entering application maintenance mode
-  #  window="<window>"  # set weekly UTC maintenance window for DATABASE
+  # manage maintenance for <DATABASE>
+  # info               # show current maintenance information
+  # run                # start maintenance
+  #   -f, --force      #   run pg:maintenance without entering application maintenance mode
+  # window="<window>"  # set weekly UTC maintenance window for DATABASE
   #                     # eg: `heroku pg:maintenance window="Sunday 14:30"`
   def maintenance
     requires_preauth
@@ -501,12 +501,12 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:links <create|destroy>
   #
-  #  Create links between data stores.  Without a subcommand, it lists all
-  #  databases and information on the link.
+  # Create links between data stores.  Without a subcommand, it lists all
+  # databases and information on the link.
   #
-  #  create <REMOTE> <LOCAL>   # Create a data link
-  #    --as <LINK>              # override the default link name
-  #  destroy <LOCAL> <LINK>    # Destroy a data link between a local and remote database
+  # create <REMOTE> <LOCAL>   # Create a data link
+  #   --as <LINK>              # override the default link name
+  # destroy <LOCAL> <LINK>    # Destroy a data link between a local and remote database
   #
   def links
     mode = shift_argument || 'list'

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -8,7 +8,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   #
   #   --wait-interval SECONDS      # how frequently to poll (to avoid rate-limiting)
   #
-  # Copy all data from source database to target. At least one of
+  # copy all data from source database to target. At least one of
   # these must be a Heroku Postgres database.
   #
   def copy
@@ -53,7 +53,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:backups [subcommand]
   #
-  # Interact with built-in backups. Without a subcommand, it lists all
+  # interact with built-in backups. Without a subcommand, it lists all
   # available backups. The subcommands available are:
   #
   #  info BACKUP_ID                 # get information about a specific backup


### PR DESCRIPTION
The pg:info command has been updated to display attachments and resources in a consolidated way that makes more sense in a Shareable world.

All this really means is not displaying multiple groups of data, if they are for the same logical database as well as displaying the Resource name in addition to Attachment names.

Before:

```
=== HEROKU_POSTGRESQL_IVORY_URL # resource: walking-slowly-1234
No data sources are linked into this database.

=== HEROKU_POSTGRESQL_RED_URL # resource: walking-slowly-1234
No data sources are linked into this database.
```

After:

```
=== HEROKU_POSTGRESQL_RED_URL, HEROKU_POSTGRESQL_IVORY_URL (walking-slowly-1234)
No data sources are linked into this database.
```

This also makes a couple minor things like indentation and capitalization consistent within PG commands.

@dickeyxxx 
@heroku/department-of-data 
cc @heroku/add-ons 