### PR TITLE
Add a pg:tunnel command for opening SSH tunnels

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -164,6 +164,29 @@ class Heroku::Command::Pg < Heroku::Command::Base
     end
   end
 
+  # pg:tunnel [DATABASE]
+  #
+  # open an SSH tunnel to a database
+  #
+  # defaults to DATABASE_URL databases if no DATABASE is specified
+  #
+  def tunnel
+    requires_preauth
+    attachment = generate_resolver.resolve(shift_argument, "DATABASE_URL")
+    validate_arguments!
+
+    uri = URI.parse( attachment.url )
+
+    if attachment.uses_bastion?
+      attachment.maybe_tunnel do |uri|
+        puts "---> Tunnel to #{attachment.display_name} open at #{uri.host}:#{uri.port}"
+        sleep
+      end
+    else
+      error("#{attachment.display_name} does not use a bastion, so no tunnel is available")
+    end
+  end
+
   # pg:reset DATABASE
   #
   # delete all data in DATABASE

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -177,9 +177,15 @@ class Heroku::Command::Pg < Heroku::Command::Base
     attachment = generate_resolver.resolve(shift_argument, "DATABASE_URL")
     validate_arguments!
 
+    local_port = options[:port]
+    if local_port
+      # Port must be a number, not a string
+      local_port = local_port.to_i
+    end
+
     if attachment.uses_bastion?
       begin
-        attachment.maybe_tunnel(options[:port]) do |uri|
+        attachment.maybe_tunnel(local_port) do |uri|
           puts "---> Tunnel to #{attachment.display_name} open at #{uri.host}:#{uri.port}"
           puts "---> Press Ctrl-C to close the tunnel"
           sleep

--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -47,26 +47,33 @@ module Heroku::Helpers::HerokuPostgresql
       !!(bastions && bastion_key)
     end
 
-    def maybe_tunnel
+    def maybe_tunnel(local_port=nil)
       require "net/ssh/gateway"
 
+      local_port_specified = local_port != nil
       uri = URI.parse(url)
       if uses_bastion?
         bastion_host = bastions.sample
         gateway = Net::SSH::Gateway.new(bastion_host, 'bastion',
           paranoid: false, timeout: 15, key_data: [bastion_key])
         begin
-          local_port = rand(65535 - 49152) + 49152
+          if not local_port_specified
+            local_port = rand(65535 - 49152) + 49152
+          end
           gateway.open(uri.host, uri.port, local_port) do |actual_local_port|
             uri.host = 'localhost'
             uri.port = actual_local_port
             yield uri
           end
         rescue Errno::EADDRINUSE
-          # Get a new random port if a local binding was not possible.
-          gateway && gateway.shutdown!
-          gateway = nil
-          retry
+          if local_port_specified
+            raise
+          else
+            # Get a new random port if a local binding was not possible.
+            gateway && gateway.shutdown!
+            gateway = nil
+            retry
+          end
         ensure
           gateway && gateway.shutdown!
         end


### PR DESCRIPTION
This allows users to access private VPC databases from the outside, using non-psql tools, including GUIs. The command simply opens an SSH tunnel and outputs the local port to use for the Postgres connection. Also includes an optional parameter for specifying a port number, which will allow users to store a connection config in their tools of choice, using a consistent port number.

I couldn't find any prior tests for the bastion tunneling, so I haven't added any here either. Any guidance in that area would be appreciated, if such tests are necessary for a merge.