### PR TITLE
Improve handling of shareable add-ons w.r.t. Postgres backups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,3 @@ DEPENDENCIES
   rr
   rspec
   webmock
-
-BUNDLED WITH
-   1.10.6

--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -112,7 +112,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
   def arbitrary_app_db
-    generate_resolver.all_databases.values.first
+    generate_resolver.all_databases.values.find do |attachment|
+      attachment.billing_app == app
+    end
   end
 
   def transfer_name(transfer)

--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -7,7 +7,8 @@ module Heroku::Helpers::HerokuPostgresql
   extend Heroku::Helpers
 
   class Attachment
-    attr_reader :app, :name, :config_var, :resource_name, :url, :addon, :plan
+    attr_reader :app, :name, :config_var, :resource_name,
+                :url, :addon, :plan, :billing_app
     attr_reader :bastions, :bastion_key
 
     def initialize(raw)
@@ -18,6 +19,7 @@ module Heroku::Helpers::HerokuPostgresql
       @resource_name = raw['resource']['name']
       @url           = raw['resource']['value']
       @addon, @plan  = raw['resource']['type'].split(':')
+      @billing_app   = raw['resource']['billing_app']['name']
 
       # Optional Bastion information for tunneling.
       if config = raw['config']

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -187,6 +187,24 @@ EOF
         expect(stderr).to match(/example has no heroku-postgresql databases/)
         expect(stdout).to be_empty
       end
+
+      it "ignores attached databases that belong to other billing apps" do
+        allow_any_instance_of(Heroku::Helpers::HerokuPostgresql::Resolver)
+          .to receive(:app_attachments)
+               .and_return([ Heroku::Helpers::HerokuPostgresql::Attachment
+                             .new({
+                                    'app' => {'name' => 'example'},
+                                    'name' => 'HEROKU_POSTGRESQL_IVORY',
+                                    'config_var' => 'HEROKU_POSTGRESQL_IVORY_URL',
+                                    'resource' => {'name'  => 'loudly-yelling-1232',
+                                                   'value' => ivory_url,
+                                                   'type'  => 'heroku-postgresql:standard-0',
+                                                   'billing_app' => { 'name' => 'sushi' } }})
+                           ])
+        stderr, stdout = execute("pg:backups schedules")
+        expect(stderr).to match(/example has no heroku-postgresql databases/)
+        expect(stdout).to be_empty
+      end
     end
 
     describe "heroku pg:backups schedule" do

--- a/spec/heroku/command/pg_backups_spec.rb
+++ b/spec/heroku/command/pg_backups_spec.rb
@@ -18,21 +18,24 @@ module Heroku::Command
             'config_var' => 'HEROKU_POSTGRESQL_IVORY_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
                            'value' => ivory_url,
-                           'type'  => 'heroku-postgresql:standard-0' }}),
+                           'type'  => 'heroku-postgresql:standard-0',
+                           'billing_app' => { 'name' => 'example' } }}),
           Heroku::Helpers::HerokuPostgresql::Attachment.new({
             'app' => {'name' => 'example'},
             'name' => 'HEROKU_POSTGRESQL_GREEN',
             'config_var' => 'HEROKU_POSTGRESQL_GREEN_URL',
             'resource' => {'name'  => 'softly-mocking-123',
                            'value' => green_url,
-                           'type'  => 'heroku-postgresql:standard-0' }}),
+                           'type'  => 'heroku-postgresql:standard-0',
+                           'billing_app' => { 'name' => 'example' }  }}),
           Heroku::Helpers::HerokuPostgresql::Attachment.new({
             'app' => {'name' => 'example'},
             'name' => 'HEROKU_POSTGRESQL_RED',
             'config_var' => 'HEROKU_POSTGRESQL_RED_URL',
             'resource' => {'name'  => 'whatever-something-2323',
                            'value' => red_url,
-                           'type'  => 'heroku-postgresql:standard-0' }})
+                           'type'  => 'heroku-postgresql:standard-0',
+                           'billing_app' => { 'name' => 'example' }  }})
       ]
     end
 
@@ -44,7 +47,8 @@ module Heroku::Command
             'config_var' => 'HEROKU_POSTGRESQL_TEAL_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
                            'value' => teal_url,
-                           'type'  => 'heroku-postgresql:standard-0' }})
+                           'type'  => 'heroku-postgresql:standard-0',
+                           'billing_app' => { 'name' => 'aux-example' }  }})
       ]
     end
 
@@ -207,7 +211,8 @@ EOF
                                       'config_var' => 'ALSO_HEROKU_POSTGRESQL_IVORY_URL',
                                       'resource' => {'name'  => 'loudly-yelling-1239',
                                                      'value' => 'postgres:///not-actually-ivory',
-                                                     'type'  => 'heroku-postgresql:standard-0' }})
+                                                     'type'  => 'heroku-postgresql:standard-0',
+                                                     'billing_app' => { 'name' => 'example' }  }})
         example_attachments << additional_attachment
         stub_pg.schedule({ hour: '07', timezone: 'UTC',
                            schedule_name: 'HEROKU_POSTGRESQL_IVORY_URL' })

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -12,21 +12,24 @@ module Heroku::Command
             'config_var' => 'HEROKU_POSTGRESQL_IVORY_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
                            'value' => 'postgres://database_url',
-                           'type'  => 'heroku-postgresql:ronin' }}),
+                           'type'  => 'heroku-postgresql:ronin',
+                           'billing_app' => { 'name' => 'example' } }}),
           Heroku::Helpers::HerokuPostgresql::Attachment.new({
             'app' => {'name' => 'example'},
             'name' => 'HEROKU_POSTGRESQL_RONIN',
             'config_var' => 'HEROKU_POSTGRESQL_RONIN_URL',
             'resource' => {'name'  => 'softly-mocking-123',
                            'value' => 'postgres://ronin_database_url',
-                           'type'  => 'heroku-postgresql:ronin' }}),
+                           'type'  => 'heroku-postgresql:ronin',
+                           'billing_app' => { 'name' => 'example' } }}),
           Heroku::Helpers::HerokuPostgresql::Attachment.new({
             'app' => {'name' => 'example'},
             'name' => 'HEROKU_POSTGRESQL_FOLLOW',
             'config_var' => 'HEROKU_POSTGRESQL_FOLLOW_URL',
             'resource' => {'name'  => 'whatever-something-2323',
                            'value' => 'postgres://follow_database_url',
-                           'type'  => 'heroku-postgresql:ronin' }})
+                           'type'  => 'heroku-postgresql:ronin',
+                           'billing_app' => { 'name' => 'example' } }})
         ].concat(extra_attachments))
       end
 
@@ -373,7 +376,8 @@ STDOUT
             'config_var' => remote + '_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
               'value' => "postgres://someurl.test/#{remote}",
-              'type'  => 'heroku-postgresql:ronin'}})
+              'type'  => 'heroku-postgresql:ronin',
+              'billing_app' => { 'name' => 'example' }}})
           local_url   = "postgres:///#{local}"
 
           dump_restore = double()
@@ -413,7 +417,8 @@ STDOUT
             'config_var' => remote + '_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
               'value' => "postgres://someurl.test/#{remote}",
-              'type'  => 'heroku-postgresql:ronin'}})
+              'type'  => 'heroku-postgresql:ronin',
+              'billing_app' => { 'name' => 'example' }}})
           local_url   = "postgres:///#{local}"
           dump_restore = double()
           expect(pg).to receive(:resolve_heroku_attachment).and_return(
@@ -467,7 +472,8 @@ STDOUT
             'config_var' => 'DATABASE_URL',
             'resource' => {'name'  => 'loudly-yelling-1232',
                            'value' => 'postgres://database_url',
-                           'type'  => 'heroku-postgresql:ronin' }})
+                           'type'  => 'heroku-postgresql:ronin',
+                           'billing_app' => { 'name' => 'sushi' } }})
         ])
 
         stderr, stdout = execute("pg:links")

--- a/spec/heroku/helpers/heroku_postgresql_spec.rb
+++ b/spec/heroku/helpers/heroku_postgresql_spec.rb
@@ -46,13 +46,15 @@ describe Heroku::Helpers::HerokuPostgresql::Resolver do
                        'app' => {'name' => 'sushi' },
                        'resource' => {'name'  => 'softly-mocking-123',
                                       'value' => 'postgres://default',
-                                      'type'  => 'heroku-postgresql:baku' }}),
+                                      'type'  => 'heroku-postgresql:baku',
+                                      'billing_app' => { 'name' => 'sushi' }}}),
       Attachment.new({ 'name'  => 'HEROKU_POSTGRESQL_BLACK',
                        'config_var' => 'HEROKU_POSTGRESQL_BLACK_URL',
                        'app' => {'name' => 'sushi' },
                        'resource' => {'name'  => 'quickly-yelling-2421',
                                       'value' => 'postgres://black',
-                                      'type'  => 'heroku-postgresql:zilla' }})
+                                      'type'  => 'heroku-postgresql:zilla',
+                                      'billing_app' => { 'name' => 'sushi' } }})
     ]
   }
 


### PR DESCRIPTION
Since Postgres backups are tied to the app and not the add-on, but
we require *an* add-on to interact with, make sure that that add-on
is attached to the right app.