### PR TITLE
Remove 9.1 warning on pg:diagnose output

### DIFF
--- a/lib/heroku/helpers/pg_diagnose.rb
+++ b/lib/heroku/helpers/pg_diagnose.rb
@@ -42,8 +42,6 @@ module Heroku::Helpers::PgDiagnose
     attachment = generate_resolver.resolve(db_id, "DATABASE_URL")
     validate_arguments!
 
-    warn_old_databases(attachment)
-
     metrics = get_metrics(attachment)
 
     params = {
@@ -58,13 +56,6 @@ module Heroku::Helpers::PgDiagnose
                       :expects => [200, 201],
                       :body => params.to_json,
                       :headers => {"Content-Type" => "application/json"})
-  end
-
-  def warn_old_databases(attachment)
-    @uri = URI.parse(attachment.url) # for #nine_two?
-    if !nine_two?
-      warn "WARNING: pg:diagnose is only fully supported on Postgres version >= 9.2. Some checks will be skipped.\n\n"
-    end
   end
 
   def get_metrics(attachment)


### PR DESCRIPTION
This fixes pg:diagnose which was broken by [this patch](https://github.com/heroku/heroku/pull/1670#issuecomment-147844552) 

I do not understand the changes to exec_sql with that patch by @fdr and then [a later patch](https://github.com/heroku/heroku/pull/1707) by @gregburek for re-using the connection or something well enough to get the warning to still print in a reasonable amount of time.

There are not that many customers left on 9.1, so I think it's fine to simply remove the message. They'll see that the checks were skipped, just not know why. I think this is a reasonable tradeoff.