### PR TITLE
Fix documentation for pg:maintenance

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -413,7 +413,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
   end
 
 
-  # pg:maintenance <info|run|set-window> <DATABASE>
+  # pg:maintenance <info|run|window> <DATABASE>
   #
   # manage maintenance for <DATABASE>
   # info               # show current maintenance information


### PR DESCRIPTION
At present the documentation for pg:maintenance is incorrect:

```
$ heroku pg:maintenance info -a equipe-app
Usage: heroku pg:maintenance <info|run|set-window> <DATABASE>

 manage maintenance for <DATABASE>
 info               # show current maintenance information
 run                # start maintenance
   -f, --force      #   run pg:maintenance without entering application maintenance mode
 window="<window>"  # set weekly UTC maintenance window for DATABASE
                     # eg: `heroku pg:maintenance window="Sunday 14:30"`
```

notice `Usage: heroku pg:maintenance <info|run|set-window> <DATABASE>`

it should be `Usage: heroku pg:maintenance <info|run|window> <DATABASE>`

This PR addresses that