### PR TITLE
Use attachment SSO url if it can be determined

### DIFF
--- a/spec/support/addons_helper.rb
+++ b/spec/support/addons_helper.rb
@@ -42,7 +42,8 @@ module Support
         created_at: Time.now,
         id:         attachment.fetch(:id, SecureRandom.uuid),
         name:       attachment[:name],
-        updated_at: Time.now
+        updated_at: Time.now,
+        web_url:    "https://attachment-sso"
       }
     end
 


### PR DESCRIPTION
This is a bit finicky compared to the Dashboard because we're getting an
arbitrary identifier which might be for an add-on or an attachments. This
attempts to resolve an attachment with the identifier but silently falls back
on add-on if it gives either a 404 or a 422 for multiple matches.

attn: @heroku/add-ons 