### PR TITLE
Fix Windows cryllic character from ENV issues

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -2,6 +2,7 @@ require "cgi"
 require "heroku"
 require "heroku/client"
 require "heroku/helpers"
+require "heroku/helpers/env"
 
 require "netrc"
 
@@ -134,7 +135,10 @@ class Heroku::Auth
     end
 
     def netrc_path
-      default = Netrc.default_path
+      default = File.join(Heroku::Helpers::Env['NETRC'] || home_directory, Netrc.netrc_filename)
+      # note: the ruby client tries to drop in `pwd` if home does not exist
+      # but the go client does not, so we do not want the fallback logic
+
       encrypted = default + ".gpg"
       if File.exists?(encrypted)
         encrypted

--- a/lib/heroku/helpers/env.rb
+++ b/lib/heroku/helpers/env.rb
@@ -1,0 +1,15 @@
+module Heroku
+  module Helpers
+    class Env
+      def self.[](key)
+        val = ENV[key]
+    
+        if val && Heroku::Helpers.running_on_windows? && val.encoding == Encoding::ASCII_8BIT
+          val = val.dup.force_encoding('utf-8')
+        end
+    
+        val
+      end
+    end
+  end
+end

--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -1,4 +1,5 @@
 require 'rbconfig'
+require 'heroku/helpers/env'
 
 class Heroku::JSPlugin
   extend Heroku::Helpers
@@ -108,10 +109,13 @@ class Heroku::JSPlugin
   end
 
   def self.app_dir
-    if windows? && ENV['LOCALAPPDATA']
-      File.join(ENV['LOCALAPPDATA'], 'heroku').encode('windows-1252')
-    elsif ENV['XDG_DATA_HOME']
-      File.join(ENV['XDG_DATA_HOME'], 'heroku')
+    localappdata = Heroku::Helpers::Env['LOCALAPPDATA']
+    xdg_data_home = Heroku::Helpers::Env['XDG_DATA_HOME']
+
+    if windows? && localappdata
+      File.join(localappdata, 'heroku')
+    elsif xdg_data_home
+      File.join(xdg_data_home, 'heroku')
     else
       File.join(Heroku::Helpers.home_directory, '.heroku')
     end

--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -23,6 +23,7 @@ module Heroku
         File.read(path).split("\n").map {|line| "#{line}\n"}
       end
 
+      allow(Heroku::Auth).to receive(:home_directory).and_return(Heroku::Helpers.home_directory)
       FileUtils.mkdir_p(@cli.netrc_path.split("/")[0..-2].join("/"))
 
       File.open(@cli.netrc_path, "w") do |file|

--- a/spec/heroku/helpers/env_spec.rb
+++ b/spec/heroku/helpers/env_spec.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+#
+require "spec_helper"
+require "heroku/helpers/env"
+
+module Heroku::Helpers
+  describe Env do
+    context "[]" do
+
+      before do
+        allow(ENV).to receive(:[]).and_return(nil)
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_return(true)
+      end
+
+      after do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_call_original
+      end
+
+      it "Passes through non ASCII-8BIT strings without re-encoding" do
+        allow(ENV).to receive(:[]).with('foo').and_return("foo".encode("ISO-8859-1"))
+
+        actual = Heroku::Helpers::Env['foo']
+
+        expect(actual).to eq("foo")
+        expect(actual.encoding).to eq(Encoding::ISO_8859_1)
+      end
+
+      it "Passes through nil without failing" do
+        allow(ENV).to receive(:[]).with('foo').and_return(nil)
+        expect(Heroku::Helpers::Env['foo']).to be_nil
+      end
+
+      it "Attempts to convert ASCII_8BIT" do
+        bad_encoding = "\u0412".force_encoding("ASCII-8BIT").freeze # verify we work with frozen values
+        allow(ENV).to receive(:[]).with('foo').and_return(bad_encoding)
+
+        actual = Heroku::Helpers::Env['foo']
+
+        expect(actual).to eq("\u0412")
+        expect(actual.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+  end
+end

--- a/spec/heroku/helpers_spec.rb
+++ b/spec/heroku/helpers_spec.rb
@@ -64,5 +64,114 @@ OUT
 
     end
 
+    context "home_directory" do
+      before do
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_return(true)
+
+        # I would much rather have removed / set ENV variables here, 
+        # but things get manged by the []= operator in windows.
+        #
+        # ENV['f'] = "\u0412" ; ENV['f'].encoding == ASCII-8BIT
+        allow(ENV).to receive(:[]).and_return(nil)
+
+        @tmp_dir = Dir.mktmpdir.encode('utf-8')
+        @home_dir = File.join(@tmp_dir, "\u0412")
+        @windows_home_dir = @home_dir.gsub(/\//, "\\")
+        Dir.mkdir(@home_dir)
+      end
+
+      after do
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_call_original
+        allow(ENV).to receive(:[]).and_call_original
+
+        Dir.rmdir(@home_dir)
+        Dir.rmdir(@tmp_dir)
+      end
+
+      it "should throw ArgumentError when nothing is defined" do
+        expect{ Heroku::Helpers.orig_home_directory }.to raise_error(ArgumentError)
+      end
+
+      it "should handle crillic characters properly in HOME" do
+        allow(ENV).to receive(:[]).with("HOME").and_return(@windows_home_dir)
+        allow(ENV).to receive(:[]).with("HOMEPATH").and_return("foo")
+        allow(ENV).to receive(:[]).with("HOMEDRIVE").and_return("bar")
+        allow(ENV).to receive(:[]).with("USERPROFILE").and_return("biz")
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+
+      it "should not use HOMEDRIVE when HOMEPATH is not defined" do
+        allow(ENV).to receive(:[]).with("HOMEDRIVE").and_return(@windows_home_dir[0..1])
+        expect{ Heroku::Helpers.orig_home_directory }.to raise_error(ArgumentError)
+      end
+
+      it "should handle crillic characters properly in HOMEDRIVE / HOMEPATH" do
+        allow(ENV).to receive(:[]).with("HOMEDRIVE").and_return(@windows_home_dir[0..1])
+        allow(ENV).to receive(:[]).with("HOMEPATH").and_return(@windows_home_dir[2..-1])
+        allow(ENV).to receive(:[]).with("USERPROFILE").and_return("biz")
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+
+      it "should handle crillic characters properly in USERPROFILE" do
+        allow(ENV).to receive(:[]).with("USERPROFILE").and_return(@windows_home_dir)
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+    end
+
+    context "home_directory (compatibility)" do
+      before do
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_return(true)
+
+        # I would much rather have removed / set ENV variables here, 
+        # but things get manged by the []= operator in windows.
+        #
+        # ENV['f'] = "\u0412" ; ENV['f'].encoding == ASCII-8BIT
+        @home = ENV.delete('HOME')
+        @home_drive = ENV.delete('HOMEDRIVE')
+        @home_path = ENV.delete('HOMEPATH')
+        @user_profile = ENV.delete('USERPROFILE')
+
+        @home_dir = Heroku::Helpers.home_directory
+        @windows_home_dir = @home_dir.gsub(/\//, "\\")
+      end
+
+      after do
+        allow(Heroku::Helpers).to receive(:running_on_windows?).and_call_original
+
+        ENV['HOME'] = @home
+        ENV['HOMEDRIVE'] = @home_drive
+        ENV['HOMEPATH'] = @home_path
+        ENV['USERPROFILE'] = @user_profile
+      end
+
+      it "should throw ArgumentError when nothing is defined" do
+        expect{ Heroku::Helpers.orig_home_directory }.to raise_error(ArgumentError)
+      end
+
+      it "should use HOME" do
+        ENV["HOME"] = @windows_home_dir
+        ENV["HOMEPATH"] = "foo"
+        ENV["HOMEDRIVE"] = "bar"
+        ENV["USERPROFILE"] = "biz"
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+
+      it "should not use HOMEDRIVE when HOMEPATH is not defined" do
+        ENV["HOMEDRIVE"] = @windows_home_dir[0..1]
+        expect{ Heroku::Helpers.orig_home_directory }.to raise_error(ArgumentError)
+      end
+
+      it "should use HOMEDRIVE / HOMEPATH" do
+        ENV["HOMEDRIVE"] = @windows_home_dir[0..1]
+        ENV["HOMEPATH"] = @windows_home_dir[2..-1]
+        ENV["USERPROFILE"] = "biz"
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+
+      it "should use USERPROFILE" do
+        ENV["USERPROFILE"] = @windows_home_dir
+        expect(Heroku::Helpers.orig_home_directory).to eq(@home_dir)
+      end
+    end
   end
 end

--- a/spec/heroku/jsplugin_spec.rb
+++ b/spec/heroku/jsplugin_spec.rb
@@ -56,5 +56,35 @@ module Heroku
         expect(Heroku::JSPlugin.shelljoin(["`$()|;", "&><'\""])).to eq("\\`\\$\\(\\)\\|\\; \\&\\>\\<\\'\\\"")
       end
     end
+
+    context "app_dir" do
+      before do
+        allow(Heroku::JSPlugin).to receive(:windows?).and_return(true)
+        allow(ENV).to receive(:[]).and_return(nil)
+      end
+
+      it "should use LOCALAPPDATA only in windows" do
+        allow(ENV).to receive(:[]).with("LOCALAPPDATA").and_return("foo")
+        allow(ENV).to receive(:[]).with("XDG_DATA_HOME").and_return("bar")
+        expect(Heroku::JSPlugin.app_dir).to eq(File.join("foo", "heroku"))
+
+        allow(Heroku::JSPlugin).to receive(:windows?).and_return(false)
+        expect(Heroku::JSPlugin.app_dir).to eq(File.join("bar", "heroku"))
+      end
+
+      it "should not use XDG_DATA_HOME if defined" do
+        allow(ENV).to receive(:[]).with("XDG_DATA_HOME").and_return("bar")
+        expect(Heroku::JSPlugin.app_dir).to eq(File.join("bar", "heroku"))
+      end
+
+      it "should default to home directory" do
+        expect(Heroku::JSPlugin.app_dir).to eq(File.join(Heroku::Helpers.home_directory, ".heroku"))
+      end
+
+      after do
+        allow(Heroku::JSPlugin).to receive(:windows?).and_call_original
+        allow(ENV).to receive(:[]).and_call_original
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -220,7 +220,7 @@ end
 require "heroku/helpers"
 module Heroku::Helpers
   @home_directory = Dir.mktmpdir
-  undef_method :home_directory
+  alias_method :orig_home_directory, :home_directory
   def home_directory
     @home_directory
   end


### PR DESCRIPTION
The underlying problem is that ENV variables with cryllic
characters come in as ASCII-8BIT rather than utf-8

* https://bugs.ruby-lang.org/issues/9715