### PR TITLE
remove duplicate command names in suggester

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -201,7 +201,7 @@ module Heroku
       else
         error([
           "`#{cmd}` is not a heroku command.",
-          suggestion(cmd, commands.keys + command_aliases.keys),
+          suggestion(cmd, (commands.keys + command_aliases.keys).uniq),
           "See `heroku help` for a list of available commands."
         ].compact.join("\n"))
       end


### PR DESCRIPTION
because we actually have multiple commands that are the same
(ruby + node for example). We need to uniquely filter this list.

To repro: `heroku remote help`