### PR TITLE
Partition regions in Common Runtime and Private Spaces

### DIFF
--- a/lib/heroku/api/regions_v3.rb
+++ b/lib/heroku/api/regions_v3.rb
@@ -1,0 +1,14 @@
+module Heroku
+  class API
+    def get_regions_v3
+      request(
+        :method => :get,
+        :expects => [200],
+        :path => "/regions",
+        :headers => {
+          "Accept" => "application/vnd.heroku+json; version=3"
+        }
+      )
+    end
+  end
+end

--- a/lib/heroku/command/regions.rb
+++ b/lib/heroku/command/regions.rb
@@ -1,4 +1,5 @@
 require "heroku/command/base"
+require "heroku/api/regions_v3"
 
 # list available regions
 #
@@ -11,13 +12,26 @@ class Heroku::Command::Regions < Heroku::Command::Base
   #Example:
   #
   # $ heroku regions
-  # === Regions
-  # us
-  # eu
+  # === Common Runtime
+  # eu         Europe
+  # us         United States
+  #
+  # === Private Spaces
+  # frankfurt  Frankfurt, Germany
+  # oregon     Oregon, United States
+  # tokyo      Tokyo, Japan
+  # virginia   Virginia, United States
   def index
-    regions = json_decode(heroku.get("/regions"))
-    styled_header("Regions")
-    styled_array(regions.map { |region| [region["slug"], region["name"]] })
+    ps, cr = api.get_regions_v3.body.partition { |r| r["private_capable"] }
+    styled_regions("Common Runtime", cr)
+    styled_regions("Private Spaces", ps)
+  end
+
+  private
+
+  def styled_regions(title, regions)
+    styled_header(title)
+    styled_array(regions.map { |r| [r["name"], r["description"]] })
   end
 end
 

--- a/spec/heroku/command/regions_spec.rb
+++ b/spec/heroku/command/regions_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+require "heroku/command/regions"
+
+module Heroku::Command
+  describe Regions do
+
+    before do
+      # stub_core
+      Excon.stub(
+        :headers => { "Accept" => "application/vnd.heroku+json; version=3" },
+        :method => :get,
+        :path => "/regions") do
+          {
+            :body => '[
+              {
+                  "country":"Ireland",
+                  "created_at":"2013-09-19T01:29:12Z",
+                  "description":"Europe",
+                  "id":"ed30241c-ed8c-4bb6-9714-61953675d0b4",
+                  "locale":"Dublin",
+                  "name":"eu",
+                  "private_capable":false,
+                  "provider":{
+                    "name":"amazon-web-services",
+                    "region":"eu-west-1"
+                  },
+                  "updated_at":"2015-08-20T01:37:59Z"
+                },
+                {
+                  "country":"Japan",
+                  "created_at":"2015-08-20T01:37:59Z",
+                  "description":"Tokyo, Japan",
+                  "id":"478864c7-3c1a-4fbd-992b-7c6160abfb71",
+                  "locale":"Tokyo",
+                  "name":"tokyo",
+                  "private_capable":true,
+                  "provider":{
+                    "name":"amazon-web-services",
+                    "region":"ap-northeast-1"
+                  },
+                  "updated_at":"2015-08-20T01:37:59Z"
+                },
+                {
+                  "country":"United States",
+                  "created_at":"2012-11-21T21:44:16Z",
+                  "description":"United States",
+                  "id":"59accabd-516d-4f0e-83e6-6e3757701145",
+                  "locale":"Virginia",
+                  "name":"us",
+                  "private_capable":false,
+                  "provider":{
+                    "name":"amazon-web-services",
+                    "region":"us-east-1"
+                  },
+                  "updated_at":"2015-08-20T01:37:59Z"
+                }
+            ]',
+          }
+      end
+    end
+
+    it "shows regions paritioned into runtimes" do
+      stderr, stdout = execute("regions")
+      expect(stderr).to eq("")
+      expect(stdout).to eq <<-STDOUT
+=== Common Runtime
+eu  Europe
+us  United States
+
+=== Private Spaces
+tokyo  Tokyo, Japan
+
+STDOUT
+    end
+
+  end
+end


### PR DESCRIPTION
To match [what is shown in Devcenter](https://devcenter.heroku.com/articles/regions#view-the-list-of-available-regions), this partitions regions into separate `Common Runtime` and `Private Spaces` lists based on the new `private_capable` property introduced in v3.

cc: @dickeyxxx @jesperfj 