### PR TITLE
skip analytics on codeship

### DIFF
--- a/lib/heroku/analytics.rb
+++ b/lib/heroku/analytics.rb
@@ -28,6 +28,7 @@ class Heroku::Analytics
 
   def self.skip_analytics
     return true if ['1', 'true'].include?(ENV['HEROKU_SKIP_ANALYTICS'])
+    return true if ENV['CODESHIP'] == 'true'
     skip = Heroku::Config[:skip_analytics]
     if skip == nil
       return true unless $stdin.isatty


### PR DESCRIPTION
codeship runs as a tty so it tries to prompt for the analytics

Fixes https://github.com/heroku/toolbelt/issues/145