### PR TITLE
Clarify version for pg:upgrade

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -463,7 +463,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   # pg:upgrade REPLICA
   #
-  # unfollow a database and upgrade it to the latest PostgreSQL version
+  # unfollow a database and upgrade it to the latest stable PostgreSQL version
+  #
+  # To upgrade to another PostgreSQL version, use pg:copy instead
   #
   def upgrade
     requires_preauth


### PR DESCRIPTION
Often users will provide a `--version` flag, expecting to be able to choose the version to upgrade to. 
Currently, we upgrade to the latest stable version, so if another version is required, the `pg:copy` strategy should be used. 