### PR TITLE
Check and update the restore_from URL if it is from Dropbox

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -405,7 +405,7 @@ EOF
 
     restore_url = nil
     if restore_from =~ %r{\Ahttps?://}
-      restore_url = restore_from
+      restore_url = check_dropboxurl(restore_from)
     else
       # assume we're restoring from a backup
       if restore_from =~ /::/
@@ -669,5 +669,21 @@ EOF
       tz = remap_tzs[tz.upcase]
     end
     { :hour => hour, :timezone => tz }
+  end
+
+  def check_dropboxurl(url)
+    # Force a dump file to download instead of rendering as HTML file
+    # by specifying the dl=1 param for Dropbox URL
+    if url =~ /www.dropbox.com/ && !url.end_with?('dl=1')
+      if url.end_with?('dl=0')
+        url.sub('dl=0', 'dl=1')
+      elsif url.include?('?')
+        url + '&dl=1'
+      else
+        url + '?dl=1'
+      end
+    end
+
+    url
   end
 end


### PR DESCRIPTION
When users use a normal Dropbox URL for a dump file of `pg:backups restore` command, it fails with very ambiguous message:

````
$ heroku pg:backups restore 'https://www.dropbox.com/s/some-random-slug/rose.dump' HEROKU_POSTGRESQL_YELLOW_URL -a sushi
...
r014 ---restore---> HEROKU_POSTGRESQL_YELLOW
An error occurred and your backup did not finish.

Please run `heroku pg:backups info r014` for details.
```

```
$ heroku pg:backups info r013 -a sushi
...
=== Backup Logs
2016-05-01 18:42:53 +0000: pg_restore: [archiver] did not find magic string in file header
...
```

This is because that Dropbox URL actually gives you an HTML file, instead of the actual dump file. You can get the dump file [by specifying `dl=1` at the end of URL](https://www.dropbox.com/help/201), this PR is checking it and actually append it.
Alternatively, we could just raise the warning instead (that was my initial intention as you can see from the brunch name -- pg:backups command doesn't give you meaningful error messages in general), or we could do something at [transferatu](https://github.com/heroku/transferatu) or [htcat](https://github.com/htcat/htcat) level.