### PR TITLE
Update heroku from 3.43.2 to 3.43.3 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroku (3.43.2)
+    heroku (3.43.3)
       heroku-api (= 0.4.2)
       launchy (= 2.4.3)
       multi_json (= 1.11.2)


### PR DESCRIPTION
Thank you for nice gem 👍 

I fix below build error on Travis CI.

https://travis-ci.org/heroku/heroku/builds/133350434
