### PR TITLE
set commands to always run as ruby

### DIFF
--- a/lib/heroku/jsplugin.rb
+++ b/lib/heroku/jsplugin.rb
@@ -1,10 +1,19 @@
 require 'rbconfig'
 require 'heroku/helpers/env'
 
+ALWAYS_RUBY_COMMANDS = [
+  'plugins',
+  'plugins:install',
+  'plugins:uninstall',
+  'version',
+  'update',
+]
+
 class Heroku::JSPlugin
   extend Heroku::Helpers
 
   def self.try_takeover(command, args)
+    return if ALWAYS_RUBY_COMMANDS.include?(command)
     run('dashboard', nil, []) if ARGV.length == 0
     if command == 'help' && args.length > 0
       return


### PR DESCRIPTION
right now these are ignored because they are flagged as hidden in the
new CLI. Really though we don't want these hidden, so adding this
exception in allows us to show the commands in the new CLI and still
have the old one keep the old functionality.