### PR TITLE
rescue openssl errors that appear transiently

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -461,7 +461,7 @@ EOF
                  end
         redisplay status
         ticks += 1
-      rescue RestClient::Exception
+      rescue RestClient::Exception, OpenSSL::SSL::SSLError
         backup = {}
         failed_count += 1
         if failed_count > 120


### PR DESCRIPTION
caller gets this stacktrace:

```
SSL_connect SYSCALL returned=5 errno=0 state=unknown state
/usr/lib/ruby/2.1.0/net/http.rb:920:in `connect'
/usr/lib/ruby/2.1.0/net/http.rb:920:in `block in connect'
/usr/lib/ruby/2.1.0/timeout.rb:76:in `timeout'
/usr/lib/ruby/2.1.0/net/http.rb:920:in `connect'
/usr/lib/ruby/2.1.0/net/http.rb:863:in `do_start'
/usr/lib/ruby/2.1.0/net/http.rb:852:in `start'
/usr/local/heroku/vendor/gems/rest-client-1.6.8/lib/restclient/request.rb:206:in
`transmit'
/usr/local/heroku/vendor/gems/rest-client-1.6.8/lib/restclient/request.rb:68:in
`execute'
/usr/local/heroku/vendor/gems/rest-client-1.6.8/lib/restclient/request.rb:35:in
`execute'
/usr/local/heroku/vendor/gems/rest-client-1.6.8/lib/restclient/resource.rb:51:in
`get'
/usr/local/heroku/lib/heroku/client/heroku_postgresql_backups.rb:55:in
`block (2 levels) in http_get'
/usr/local/heroku/lib/heroku/helpers.rb:126:in `retry_on_exception'
/usr/local/heroku/lib/heroku/client/heroku_postgresql_backups.rb:54:in
`block in http_get'
/usr/local/heroku/lib/heroku/client/heroku_postgresql_backups.rb:106:in
`checking_client_version'
/usr/local/heroku/lib/heroku/client/heroku_postgresql_backups.rb:53:in
`http_get'
/usr/local/heroku/lib/heroku/client/heroku_postgresql_backups.rb:20:in
`transfers_get'
/usr/local/heroku/lib/heroku/command/pg_backups.rb:455:in
`poll_transfer'
/usr/local/heroku/lib/heroku/command/pg_backups.rb:444:in
`restore_backup'
/usr/local/heroku/lib/heroku/command/pg_backups.rb:81:in `backups'
/usr/local/heroku/lib/heroku/command.rb:213:in `run'
/usr/local/heroku/lib/heroku/cli.rb:34:in `start'
/usr/local/heroku/bin/heroku:25:in `<main>'
```